### PR TITLE
Fix styled-components DefaultTheme type declarations

### DIFF
--- a/src/components/constants/ColorConstants.ts
+++ b/src/components/constants/ColorConstants.ts
@@ -26,6 +26,7 @@ interface ThemeColors {
   hotDogGold: string;
   closeLossRed: string;
   closeWinGreen: string;
+  primary: string;
 }
 
 interface ColorConstantsType {
@@ -62,6 +63,7 @@ export const ColorConstants: ColorConstantsType = {
     hotDogGold: "#FFD700",
     closeLossRed: "#bc293d",
     closeWinGreen: "#227740",
+    primary: "#1976d2",
   },
   dark: {
     link: "#1976d2",
@@ -91,6 +93,7 @@ export const ColorConstants: ColorConstantsType = {
     hotDogGold: "#FFD700",
     closeLossRed: "#bc293d",
     closeWinGreen: "#227740",
+    primary: "#1976d2",
   },
 };
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,0 +1,34 @@
+import "styled-components";
+
+declare module "styled-components" {
+  export interface DefaultTheme {
+    link: string;
+    text: string;
+    background: string;
+    componentBackground: string;
+    tableHeaderBackground: string;
+    neutral1: string;
+    neutral2: string;
+    neutral3: string;
+    neutral4: string;
+    neutral5: string;
+    newsRed: string;
+    newsBlue: string;
+    newsBlueDark: string;
+    success: string;
+    successDark: string;
+    yahoo: string;
+    button: string;
+    buttonText: string;
+    hotDogYellow: string;
+    hotDogOrange: string;
+    hotDogPink: string;
+    hotDogPurple: string;
+    hotDogBlue: string;
+    hotDogBrown: string;
+    hotDogGold: string;
+    closeLossRed: string;
+    closeWinGreen: string;
+    primary: string;
+  }
+}


### PR DESCRIPTION
## Problem

The TypeScript build fails with errors like:
- `Property 'componentBackground' does not exist on type 'DefaultTheme'`
- `Cannot find name 'process'`
- `Property 'primary' does not exist on type 'DefaultTheme'`

## Root Cause

The project uses styled-components `ThemeProvider` with a custom theme object (`ThemeColors` from `ColorConstants`), but never declared a module augmentation for `DefaultTheme`. TypeScript doesn't know what properties exist on the theme.

Additionally, `react-app-env.d.ts` was missing, so `process.env` wasn't recognized.

## Changes

- **`src/styled.d.ts`** — Augments `styled-components` `DefaultTheme` with all `ThemeColors` properties
- **`src/react-app-env.d.ts`** — Adds `/// <reference types="react-scripts" />` for CRA type support
- **`src/components/constants/ColorConstants.ts`** — Adds missing `primary` property to both the `ThemeColors` interface and the light/dark color objects

## Verification

`pnpm build` passes cleanly.