### PR TITLE
fix: swap standings/median sections when league uses median scoring

### DIFF
--- a/src/pages/LeagueWeeklyRecap.tsx
+++ b/src/pages/LeagueWeeklyRecap.tsx
@@ -284,13 +284,20 @@ export const LeagueWeeklyRecap: React.FC = () => {
         id: "standings",
         label: "Standings",
         title: "Standings",
-        subtitle: undefined as string | undefined,
-        section: newsletter.leaderboard,
-        render: () => (
-          <LeaderboardTable
-            leaderboardData={newsletter.leaderboard.data ?? []}
-          />
-        ),
+        subtitle: newsletter.isMedianLeague
+          ? "Record includes matchups against the league median"
+          : (undefined as string | undefined),
+        section: newsletter.isMedianLeague
+          ? newsletter.median
+          : newsletter.leaderboard,
+        render: () =>
+          newsletter.isMedianLeague ? (
+            <AltLeaderboardTable data={newsletter.median.data ?? []} />
+          ) : (
+            <LeaderboardTable
+              leaderboardData={newsletter.leaderboard.data ?? []}
+            />
+          ),
         skeleton: <TableSkeleton rows={10} columns={6} />,
         shouldRender: true,
       },
@@ -311,13 +318,26 @@ export const LeagueWeeklyRecap: React.FC = () => {
       },
       {
         id: "median",
-        label: "Median Scoring",
-        title: "Median Scoring Leaderboard",
-        subtitle: "Total record including matchups and games vs. league median",
-        section: newsletter.median,
-        render: () => (
-          <AltLeaderboardTable data={newsletter.median.data ?? []} />
-        ),
+        label: newsletter.isMedianLeague
+          ? "H2H Only Standings"
+          : "Median Scoring",
+        title: newsletter.isMedianLeague
+          ? "Head-to-Head Only Standings"
+          : "Median Scoring Leaderboard",
+        subtitle: newsletter.isMedianLeague
+          ? "What if we didn't play the median?"
+          : "Total record including matchups and games vs. league median",
+        section: newsletter.isMedianLeague
+          ? newsletter.leaderboard
+          : newsletter.median,
+        render: () =>
+          newsletter.isMedianLeague ? (
+            <LeaderboardTable
+              leaderboardData={newsletter.leaderboard.data ?? []}
+            />
+          ) : (
+            <AltLeaderboardTable data={newsletter.median.data ?? []} />
+          ),
         skeleton: <TableSkeleton rows={10} columns={5} />,
         shouldRender: true,
       },


### PR DESCRIPTION
When a league has `league_average_match` enabled (like league `1223730601350135814`), the median-included standings become the primary **Standings** section, and H2H-only becomes the alternate section with subtitle *"What if we didn't play the median?"*

When median scoring is NOT enabled, behavior is unchanged — H2H is primary, median is the alternate.

**Changes:**
- `useNewsletterData.ts`: Fetch league settings via `getLeague()`, expose `isMedianLeague` flag
- `LeagueWeeklyRecap.tsx`: Conditionally swap which data/component feeds Standings vs Median sections, update labels accordingly

Closes #41