### PR TITLE
chore: bump actions/checkout v3 → v4

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -8,7 +8,7 @@ jobs:
     if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Goal
Fix preview deploy comments not updating on force-pushes. Sentinel also flagged this as a nit on PR #44.

## Approach
Bump `actions/checkout` from v3 to v4 in both CI workflows. v4 has better force-push event handling which should fix the Firebase action's comment deduplication.

## Key Changes
- **firebase-hosting-merge.yml** — `actions/checkout@v3` → `@v4`
- **firebase-hosting-pull-request.yml** — `actions/checkout@v3` → `@v4`

## Testing Done
Two-line change, no build impact. CI will validate on this PR itself.