### PR TITLE
fix: dynamically scale Manager Skill Assessment chart height (closes #59)

### DIFF
--- a/src/components/newsletters/chartStyles.jsx
+++ b/src/components/newsletters/chartStyles.jsx
@@ -70,6 +70,20 @@ const getBaseBarConfig = (theme, color) => ({
     }
 });
 
+/**
+ * Calculates the chart height for the EfficiencyChart based on team count.
+ * Scales at ~35px per team with a minimum height for 4 teams.
+ * @param {number} teamCount - Number of teams in the league
+ * @returns {number} Chart height in pixels
+ */
+const getEfficiencyChartHeight = (teamCount) => {
+    const perTeamHeight = 35;
+    const minTeams = 4;
+    const padding = 60; // top + bottom padding for axes/legend
+    const effectiveTeams = Math.max(teamCount, minTeams);
+    return effectiveTeams * perTeamHeight + padding;
+};
+
 export const EfficiencyChart = ({ chartData }) => {
     const theme = useTheme();
 
@@ -93,10 +107,13 @@ export const EfficiencyChart = ({ chartData }) => {
         bins.push(i);
     }
 
+    const chartHeight = getEfficiencyChartHeight(teamNames.length);
+
     return (
         <VictoryChart
             {...getBaseChartConfig()}
             horizontal
+            height={chartHeight}
             padding={{ top: 25, bottom: 25, left: 10, right: 50 }}
             domainPadding={{ x: 10 }}
         >


### PR DESCRIPTION
## Goal
Fix the Manager Skill Assessment chart being unreadable in large leagues (32+ teams) and wasting space in small ones. Closes #59.

## Approach
Dynamically calculate the VictoryChart height based on team count instead of using the default fixed 300px height. Uses ~35px per team with a 60px padding for axes/legend, and a minimum of 4 teams to prevent the chart from being too small.

**Formula:** `height = max(teamCount, 4) * 35 + 60`

Examples:
- 4 teams → 200px
- 10 teams (typical) → 410px  
- 12 teams → 480px
- 32 teams → 1180px

## Key Changes
- **`src/components/newsletters/chartStyles.jsx`** — Added `getEfficiencyChartHeight()` helper function and passed dynamic `height` prop to the EfficiencyChart's VictoryChart component

## Testing Done
- Verified the change is syntactically correct and only affects the EfficiencyChart component
- Build could not be tested locally due to node_modules compatibility issue (ajv version conflict with CRA), unrelated to this change
- The change is minimal and isolated: adds a `height` prop to VictoryChart based on data length