### PR TITLE
feat: ESPN private league support with manual cookie entry

### DIFF
--- a/src/pages/EspnLogin.tsx
+++ b/src/pages/EspnLogin.tsx
@@ -1,8 +1,18 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { fetchLeague } from "../utils/api/ESPNApi";
 import { useAuth } from "../contexts/AuthContext";
+import {
+  getEspnCredentials,
+  saveEspnCredentials,
+  clearEspnCredentials,
+  type EspnCredentials,
+} from "../utils/espnCredentials";
+
+/* ------------------------------------------------------------------ */
+/*  Styled Components                                                  */
+/* ------------------------------------------------------------------ */
 
 const Container = styled.div`
   display: flex;
@@ -36,6 +46,15 @@ const Button = styled.button`
   opacity: ${({ disabled }: any) => (disabled ? 0.6 : 1)};
 `;
 
+const SecondaryButton = styled(Button)`
+  background-color: transparent;
+  border: 1px solid ${({ theme }: any) => theme.neutral3};
+  color: ${({ theme }: any) => theme.neutral3};
+  font-size: 13px;
+  padding: 6px 14px;
+  margin-top: 8px;
+`;
+
 const LeagueCard = styled.div`
   display: flex;
   flex-direction: column;
@@ -52,7 +71,7 @@ const HelpText = styled.p`
   font-size: 14px;
   color: ${({ theme }: any) => theme.text};
   opacity: 0.7;
-  max-width: 400px;
+  max-width: 500px;
   margin-top: 15px;
   line-height: 1.5;
 `;
@@ -61,8 +80,84 @@ const ErrorText = styled.h3`
   color: ${({ theme }: any) => theme.text};
 `;
 
+const Toggle = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+  cursor: pointer;
+  font-size: 14px;
+  color: ${({ theme }: any) => theme.text};
+`;
+
+const Checkbox = styled.input`
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+`;
+
+const CollapsibleSection = styled.div<{ $open: boolean }>`
+  max-height: ${({ $open }) => ($open ? "800px" : "0")};
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const InstructionBox = styled.details`
+  text-align: left;
+  max-width: 500px;
+  margin: 16px 0;
+  padding: 12px 16px;
+  border: 1px solid ${({ theme }: any) => theme.neutral3};
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: ${({ theme }: any) => theme.text};
+
+  summary {
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 14px;
+    margin-bottom: 8px;
+  }
+
+  ol {
+    padding-left: 20px;
+    margin: 8px 0;
+  }
+
+  code {
+    background: ${({ theme }: any) => theme.neutral3}33;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+  }
+`;
+
+const SavedBadge = styled.span`
+  display: inline-block;
+  background: #22c55e33;
+  color: #22c55e;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 8px;
+`;
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
 function EspnLogin() {
   const [leagueId, setLeagueId] = useState("");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [espnS2, setEspnS2] = useState("");
+  const [swid, setSwid] = useState("");
+  const [hasSavedCreds, setHasSavedCreds] = useState(false);
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [leagueInfo, setLeagueInfo] = useState<{
@@ -70,7 +165,20 @@ function EspnLogin() {
     size: number;
     season: number;
   } | null>(null);
+
   const navigate = useNavigate();
+  const { currentUser, addLeague } = useAuth();
+
+  // Load saved credentials from localStorage on mount
+  useEffect(() => {
+    const saved = getEspnCredentials();
+    if (saved) {
+      setEspnS2(saved.espnS2);
+      setSwid(saved.swid);
+      setIsPrivate(true);
+      setHasSavedCreds(true);
+    }
+  }, []);
 
   const handleSubmit = async () => {
     const trimmed = leagueId.trim();
@@ -79,9 +187,24 @@ function EspnLogin() {
       return;
     }
 
+    if (isPrivate && (!espnS2.trim() || !swid.trim())) {
+      setError("Please enter both espn_s2 and SWID cookies for private leagues.");
+      return;
+    }
+
     setLoading(true);
     setError(null);
     setLeagueInfo(null);
+
+    // Save credentials if private
+    if (isPrivate) {
+      const creds: EspnCredentials = {
+        espnS2: espnS2.trim(),
+        swid: swid.trim(),
+      };
+      saveEspnCredentials(creds);
+      setHasSavedCreds(true);
+    }
 
     try {
       const data = await fetchLeague(trimmed);
@@ -90,16 +213,15 @@ function EspnLogin() {
         size: data.settings.size,
         season: data.seasonId,
       });
-    } catch (err) {
-      setError(
-        "League not found. Make sure your league is public and the ID is correct."
-      );
+    } catch {
+      const msg = isPrivate
+        ? "League not found. Double-check your League ID and cookies. Make sure espn_s2 and SWID are copied correctly with no extra spaces."
+        : "League not found. Make sure your league is public and the ID is correct.";
+      setError(msg);
     } finally {
       setLoading(false);
     }
   };
-
-  const { currentUser, addLeague } = useAuth();
 
   const handleConfirm = async () => {
     const espnId = `espn_${leagueId.trim()}`;
@@ -119,9 +241,17 @@ function EspnLogin() {
     navigate(`/home/${espnId}`);
   };
 
+  const handleClearCreds = () => {
+    clearEspnCredentials();
+    setEspnS2("");
+    setSwid("");
+    setHasSavedCreds(false);
+  };
+
   return (
     <Container>
       <h1>Enter ESPN League ID</h1>
+
       <Input
         type="text"
         value={leagueId}
@@ -129,7 +259,73 @@ function EspnLogin() {
         placeholder="e.g. 123456"
         onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
       />
-      <Button onClick={handleSubmit} disabled={loading}>
+
+      <Toggle>
+        <Checkbox
+          type="checkbox"
+          checked={isPrivate}
+          onChange={(e) => setIsPrivate(e.target.checked)}
+        />
+        My league is private
+      </Toggle>
+
+      <CollapsibleSection $open={isPrivate}>
+        <InstructionBox>
+          <summary>How to find your ESPN cookies</summary>
+          <ol>
+            <li>
+              Open{" "}
+              <a href="https://fantasy.espn.com" target="_blank" rel="noreferrer">
+                fantasy.espn.com
+              </a>{" "}
+              and log in.
+            </li>
+            <li>Open your browser&apos;s Developer Tools (F12 or Cmd+Option+I on Mac).</li>
+            <li>
+              Go to the <strong>Application</strong> tab (Chrome) or <strong>Storage</strong> tab
+              (Firefox).
+            </li>
+            <li>
+              In the left sidebar, expand <strong>Cookies</strong> → click on{" "}
+              <code>https://fantasy.espn.com</code>.
+            </li>
+            <li>
+              Find <code>espn_s2</code> — copy the entire <strong>Value</strong> (it&apos;s a long
+              string).
+            </li>
+            <li>
+              Find <code>SWID</code> — copy the entire <strong>Value</strong> (looks like{" "}
+              <code>{"{XXXXXXXX-XXXX-...}"}</code>).
+            </li>
+          </ol>
+          <p>
+            <strong>Tip:</strong> These cookies expire periodically. If you get errors after a
+            while, repeat these steps to get fresh values.
+          </p>
+        </InstructionBox>
+
+        <Input
+          type="text"
+          value={espnS2}
+          onChange={(e) => setEspnS2(e.target.value)}
+          placeholder="espn_s2 cookie value"
+        />
+        {hasSavedCreds && espnS2 && <SavedBadge>Saved</SavedBadge>}
+
+        <Input
+          type="text"
+          value={swid}
+          onChange={(e) => setSwid(e.target.value)}
+          placeholder="SWID cookie value (e.g. {XXXX-...})"
+        />
+        {hasSavedCreds && swid && <SavedBadge>Saved</SavedBadge>}
+
+        {hasSavedCreds && (
+          <SecondaryButton onClick={handleClearCreds}>Clear saved cookies</SecondaryButton>
+        )}
+      </CollapsibleSection>
+
+      <Button onClick={handleSubmit} disabled={loading} style={{ marginTop: 12 }}>
         {loading ? "Looking up league..." : "Submit"}
       </Button>
 
@@ -150,11 +346,9 @@ function EspnLogin() {
       <HelpText>
         Find your League ID in the ESPN URL when viewing your league:
         <br />
-        <code>espn.com/fantasy/football/league?leagueId=<b>123456</b></code>
-        <br />
-        <br />
-        Note: Only public leagues are supported. Private league support is
-        coming in a future update.
+        <code>
+          espn.com/fantasy/football/league?leagueId=<b>123456</b>
+        </code>
       </HelpText>
     </Container>
   );

--- a/src/utils/espnCredentials.ts
+++ b/src/utils/espnCredentials.ts
@@ -1,0 +1,36 @@
+/**
+ * ESPN private league credential management.
+ *
+ * Stores espn_s2 and SWID cookies in localStorage so users
+ * don't have to re-enter them every visit.
+ */
+
+const STORAGE_KEY = "espn_credentials";
+
+export interface EspnCredentials {
+  espnS2: string;
+  swid: string;
+}
+
+/** Retrieve saved ESPN credentials (or null if none). */
+export function getEspnCredentials(): EspnCredentials | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as EspnCredentials;
+    if (parsed.espnS2 && parsed.swid) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Save ESPN credentials to localStorage. */
+export function saveEspnCredentials(creds: EspnCredentials): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(creds));
+}
+
+/** Remove saved ESPN credentials. */
+export function clearEspnCredentials(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary

Adds private league support to the ESPN login flow, implementing Option 1 from #66 (manual cookie entry).

## Changes

### New: `src/utils/espnCredentials.ts`
- `getEspnCredentials()` / `saveEspnCredentials()` / `clearEspnCredentials()`
- Stores espn_s2 and SWID in localStorage for persistence across visits

### Updated: `src/pages/EspnLogin.tsx`
- Added "My league is private" toggle checkbox
- Collapsible section with espn_s2 and SWID input fields
- Step-by-step instructions (expandable `<details>`) for finding cookies in Chrome/Firefox dev tools
- "Saved" badge when credentials are loaded from localStorage
- "Clear saved cookies" button for when they expire
- Improved error messages for private vs public league failures

### Updated: `src/utils/api/ESPNApi.ts`
- Passes saved credentials via custom headers (`X-Fantasy-espn-s2`, `X-Fantasy-SWID`)
- Added `credentials: 'include'` to send any existing ESPN cookies from the browser
- **Note:** If ESPN's CORS policy rejects custom headers, we'll need a Firebase Cloud Function proxy as a follow-up

## Testing
- Lint, format, and typecheck all pass on the new/modified files
- Manual testing needed with an actual private ESPN league

Closes #66

— Richie Incognito 🏈