### PR TITLE
fix: add missing firestore rules for leaderboards, survivor, and submissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -97,7 +97,7 @@ service cloud.firestore {
     // /survivorPicks/{docId}
     // Publicly readable (leaderboard views). Authenticated users can create
     // and update picks. No deletes from client.
-    // TODO: Restrict writes to own picks (requires userId field validation).
+    // TODO: Restrict writes to own picks (e.g. request.resource.data.userId == request.auth.uid).
     // -----------------------------------------------------------------------
     match /survivorPicks/{docId} {
       allow read: if true;


### PR DESCRIPTION
## Goal
Fix silent permission-denied errors on 5 Firestore collections that were missed when `firestore.rules` was introduced in PR #70.

## What broke
PR #70 added rules for `/users`, `/leagues` (+ subcollections), and the CI deploy step. PR #76 added `/config`. But 5 other collections used by the app had no rules — Firestore's default-deny silently killed:
- **Leaderboards** — entire feature (read)
- **Leaderboard results** — submissions + display (read + create)
- **Eaterboard** — `/leaderboard-times` (read)
- **Submit page** — anonymous newsletter submissions (create)
- **Survivor pool** — picks read/write

## Approach
Add rules matching current app behavior. Intentionally permissive to restore functionality. Each rule has a `TODO` comment for future tightening (auth, field validation, rate limiting).

## Key Changes
| Collection | Read | Write | Notes |
|---|---|---|---|
| `/leaderboards` | public | none | Admin-managed via console |
| `/leaderboard-results` | public | create (anyone) | Matches current unauthenticated submit modal |
| `/leaderboard-times` | public | none | Eaterboard display only |
| `/submissions` | none | create (anyone) | Write-only, reviewed in console |
| `/survivorPicks` | public | create+update (auth) | No deletes from client |

## Testing
- Reviewed every `getDoc`/`getDocs`/`setDoc`/`addDoc`/`updateDoc` call in the codebase
- Verified all Firestore paths now have matching rules

## Risk Level
**High** — these features are currently broken in production. This restores them.