### PR TITLE
feat: use device prefers-color-scheme as default theme

### DIFF
--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -9,8 +9,11 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState(() => {
-    // Retrieve the theme from localStorage, default to "light" if not set
-    return localStorage.getItem("theme") || "light";
+    // Retrieve the theme from localStorage, fall back to device preference
+    return (
+      localStorage.getItem("theme") ||
+      (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+    );
   });
 
   const toggleTheme = () => {


### PR DESCRIPTION
## Summary
- Falls back to the OS/browser `prefers-color-scheme` when no theme is saved in `localStorage`
- Works on iOS, Android, Windows, and macOS
- Explicit user toggle still takes priority (saved to `localStorage` as before)

Closes #75

## Test plan
- [ ] On a device set to dark mode with no prior site visit, confirm the site loads in dark mode
- [ ] Toggle the theme manually, reload — confirm the manual choice is respected
- [ ] On a device set to light mode, confirm the site loads in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)