### PR TITLE
feat: Sleeper account linking on profile page

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -95,10 +95,15 @@ const EditIcon = () => (
   </svg>
 );
 const Profile: React.FC = () => {
-  const { profile, loadingProfile, updateProfile } = useAuth();
+  const { profile, loadingProfile, updateProfile, linkSleeper } = useAuth();
   const [customDisplayName, setCustomDisplayName] = useState(profile?.customDisplayName || "");
   const [isEditing, setIsEditing] = useState(false);
   const [updating, setUpdating] = useState(false);
+
+  const [sleeperInput, setSleeperInput] = useState("");
+  const [sleeperLinking, setSleeperLinking] = useState(false);
+  const [sleeperError, setSleeperError] = useState<string | null>(null);
+  const [sleeperEditMode, setSleeperEditMode] = useState(false);
 
   const handleEdit = () => {
     setIsEditing(true);
@@ -121,6 +126,20 @@ const Profile: React.FC = () => {
   const handleCancel = () => {
     setCustomDisplayName(profile?.customDisplayName || "");
     setIsEditing(false);
+  };
+
+  const handleLinkSleeper = async () => {
+    if (!sleeperInput.trim()) return;
+    setSleeperLinking(true);
+    setSleeperError(null);
+    const result = await linkSleeper(sleeperInput.trim());
+    if (result.success) {
+      setSleeperInput("");
+      setSleeperEditMode(false);
+    } else {
+      setSleeperError(result.error ?? "Something went wrong");
+    }
+    setSleeperLinking(false);
   };
 
   if (loadingProfile) {
@@ -173,6 +192,76 @@ const Profile: React.FC = () => {
               </div>
             </div>
           )}
+        </div>
+
+        <div
+          style={{
+            borderTop: "1px solid rgba(128,128,128,0.2)",
+            paddingTop: "1rem",
+            marginTop: "0.5rem",
+            textAlign: "left",
+          }}
+        >
+          <label style={{ display: "block", marginBottom: "0.75rem", fontWeight: 600 }}>
+            Linked Accounts
+          </label>
+          <div>
+            <label style={{ display: "block", marginBottom: "0.5rem", fontSize: "0.875rem" }}>
+              Sleeper:
+            </label>
+            {profile?.sleeperUsername && !sleeperEditMode ? (
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <span>@{profile.sleeperUsername}</span>
+                <button
+                  onClick={() => {
+                    setSleeperEditMode(true);
+                    setSleeperError(null);
+                  }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    color: "inherit",
+                  }}
+                >
+                  <EditIcon />
+                </button>
+              </div>
+            ) : (
+              <div>
+                <Input
+                  type="text"
+                  placeholder="Sleeper username"
+                  value={sleeperInput}
+                  onChange={(e) => setSleeperInput(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleLinkSleeper()}
+                />
+                <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+                  <Button onClick={handleLinkSleeper} disabled={sleeperLinking}>
+                    {sleeperLinking ? "Linking..." : "Link Account"}
+                  </Button>
+                  {sleeperEditMode && (
+                    <Button
+                      onClick={() => {
+                        setSleeperEditMode(false);
+                        setSleeperInput("");
+                        setSleeperError(null);
+                      }}
+                      disabled={sleeperLinking}
+                      style={{ background: "#ccc" }}
+                    >
+                      Cancel
+                    </Button>
+                  )}
+                </div>
+                {sleeperError && (
+                  <p style={{ color: "#bc293d", fontSize: "0.875rem", marginTop: "0.5rem" }}>
+                    {sleeperError}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </Card>
     </Container>

--- a/src/utils/api/SleeperAPI.ts
+++ b/src/utils/api/SleeperAPI.ts
@@ -37,6 +37,23 @@ function dedupedFetch<T>(url: string, errorMessage: string): Promise<T> {
   return promise;
 }
 
+/**
+ * Look up a Sleeper user by username.
+ * Returns the user object if found, or null if the username doesn't exist.
+ */
+export const getSleeperUserByUsername = async (
+  username: string
+): Promise<{ user_id: string; username: string; display_name?: string } | null> => {
+  try {
+    const response = await fetch(`${BASE_URL}/user/${username}`);
+    if (!response.ok) return null;
+    const data = await response.json();
+    return data?.user_id ? data : null;
+  } catch {
+    return null;
+  }
+};
+
 // Function to get league
 export const getLeague = async (leagueId: string): Promise<League> => {
   try {

--- a/src/utils/survivorUtils.ts
+++ b/src/utils/survivorUtils.ts
@@ -50,6 +50,10 @@ export interface UserProfile {
   email?: string;
   /** User's saved leagues across platforms */
   leagues?: SavedLeague[];
+  /** Linked Sleeper account user ID */
+  sleeperUserId?: string;
+  /** Linked Sleeper account username */
+  sleeperUsername?: string;
 }
 
 export const getUserProfile = async (userId: string): Promise<UserProfile | null> => {


### PR DESCRIPTION
## Summary
- Adds a **Linked Accounts** section to the Profile page where users can enter their Sleeper username to link their account
- Validates the username against `GET /v1/user/<username>` and stores `sleeperUserId` / `sleeperUsername` in Firestore
- After linking, auto-discovers the user's current-season Sleeper leagues and saves them to `savedLeagues` (they appear immediately on the LeaguePicker dashboard)
- ESPN league saving was already complete from PR #64 — no changes needed there

Closes #51

## Test plan
- [ ] Sign in with Google → navigate to `/profile`
- [ ] Enter a valid Sleeper username → "Link Account" → profile shows `@username`
- [ ] Navigate to `/` → saved Sleeper leagues appear under "Your Leagues"
- [ ] Enter an invalid username → error message shown inline
- [ ] Click edit icon on linked username → re-link with a different account → updates correctly
- [ ] `pnpm typecheck` and `pnpm lint` pass