### PR TITLE
feat: leagues dashboard — background Sleeper refresh, platform icons, auto-create league docs

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -50,7 +50,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const auth = getAuth(app);
 
   const loadProfile = useCallback(
-    async (userId: string) => {
+    async (userId: string): Promise<UserProfile | null> => {
       setLoadingProfile(true);
       let userProfile = await getUserProfile(userId);
       const currentEmail = currentUser?.email || "";
@@ -63,6 +63,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         await setUserProfile(userId, newProfile);
         setProfile(newProfile);
         setSavedLeagues([]);
+        setLoadingProfile(false);
+        return null;
       } else if (userProfile) {
         // Update existing profile if email is missing or different
         if (!userProfile.email || userProfile.email !== currentEmail) {
@@ -73,11 +75,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setProfile(userProfile);
         }
         setSavedLeagues(userProfile.leagues ?? []);
+        setLoadingProfile(false);
+        return userProfile;
       } else {
         setProfile(null);
         setSavedLeagues([]);
+        setLoadingProfile(false);
+        return null;
       }
-      setLoadingProfile(false);
     },
     [currentUser?.displayName, currentUser?.email]
   );
@@ -86,9 +91,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setCurrentUser(user);
       if (user) {
-        await loadProfile(user.uid);
+        const loadedProfile = await loadProfile(user.uid);
         // Background refresh: sync Sleeper leagues without blocking UI
-        refreshSleeperLeagues(user.uid, setSavedLeagues);
+        refreshSleeperLeagues(
+          user.uid,
+          loadedProfile?.sleeperUserId,
+          loadedProfile?.leagues ?? [],
+          setSavedLeagues
+        );
         setLoading(false);
       } else {
         setProfile(null);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,6 +19,7 @@ import {
   SavedLeague,
 } from "../utils/survivorUtils";
 import { getSleeperUserByUsername, getNflState } from "../utils/api/SleeperAPI";
+import { refreshSleeperLeagues } from "../utils/refreshSleeperLeagues";
 
 interface AuthContextType {
   currentUser: FirebaseUser | null;
@@ -86,6 +87,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setCurrentUser(user);
       if (user) {
         await loadProfile(user.uid);
+        // Background refresh: sync Sleeper leagues without blocking UI
+        refreshSleeperLeagues(user.uid, setSavedLeagues);
         setLoading(false);
       } else {
         setProfile(null);

--- a/src/hooks/useEnsureLeagueDoc.ts
+++ b/src/hooks/useEnsureLeagueDoc.ts
@@ -1,0 +1,77 @@
+/**
+ * useEnsureLeagueDoc — ensures a Firestore `/leagues/{leagueId}` document
+ * exists the first time a user navigates to a league page.
+ *
+ * Uses an in-memory set to avoid redundant reads within a session.
+ * Only creates the doc if it doesn't already exist (no overwrites).
+ *
+ * This sets the foundation for editor role claiming (#53) — once the doc
+ * exists, an editor can claim it.
+ */
+import { useEffect, useRef } from "react";
+import { doc, getDoc, setDoc, Timestamp } from "firebase/firestore";
+import { db } from "../firebase";
+import type { Platform } from "../types/firestore";
+
+/** Track which league IDs we've already verified this session. */
+const _verified = new Set<string>();
+
+/**
+ * Detect the platform from a league ID.
+ * ESPN IDs are prefixed with "espn_", everything else is Sleeper.
+ */
+function detectPlatform(leagueId: string): Platform {
+  return leagueId.startsWith("espn_") ? "espn" : "sleeper";
+}
+
+/**
+ * Extract the raw platform league ID (strips the "espn_" prefix for ESPN).
+ */
+function extractPlatformLeagueId(leagueId: string): string {
+  return leagueId.startsWith("espn_") ? leagueId.slice(5) : leagueId;
+}
+
+/**
+ * Hook: call from any page that has a leagueId param.
+ * Ensures the Firestore league doc exists (creates a skeleton if not).
+ *
+ * @param leagueId - The league document ID (may be undefined if param missing)
+ * @param leagueName - Optional display name to set on creation
+ * @param season - Optional season year to set on creation
+ */
+export function useEnsureLeagueDoc(
+  leagueId: string | undefined,
+  leagueName?: string,
+  season?: number
+): void {
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (!leagueId || _verified.has(leagueId) || attempted.current) return;
+    attempted.current = true;
+
+    (async () => {
+      try {
+        const ref = doc(db, "leagues", leagueId);
+        const snap = await getDoc(ref);
+        if (!snap.exists()) {
+          const platform = detectPlatform(leagueId);
+          await setDoc(ref, {
+            platform,
+            platformLeagueId: extractPlatformLeagueId(leagueId),
+            name: leagueName || "",
+            season: season || new Date().getFullYear(),
+            editorUid: "",
+            coEditorUids: [],
+            privacy: "public",
+            createdAt: Timestamp.now(),
+          });
+        }
+        _verified.add(leagueId);
+      } catch (err) {
+        // Non-fatal — the page still works without the league doc
+        console.warn("[useEnsureLeagueDoc] Failed to ensure league doc:", err);
+      }
+    })();
+  }, [leagueId, leagueName, season]);
+}

--- a/src/hooks/useEnsureLeagueDoc.ts
+++ b/src/hooks/useEnsureLeagueDoc.ts
@@ -1,16 +1,18 @@
 /**
  * useEnsureLeagueDoc — ensures a Firestore `/leagues/{leagueId}` document
- * exists the first time a user navigates to a league page.
+ * exists the first time an authenticated user navigates to a league page.
  *
  * Uses an in-memory set to avoid redundant reads within a session.
  * Only creates the doc if it doesn't already exist (no overwrites).
+ * Requires authentication — anonymous visitors do not trigger writes.
  *
  * This sets the foundation for editor role claiming (#53) — once the doc
  * exists, an editor can claim it.
  */
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { doc, getDoc, setDoc, Timestamp } from "firebase/firestore";
 import { db } from "../firebase";
+import { useAuth } from "../contexts/AuthContext";
 import type { Platform } from "../types/firestore";
 
 /** Track which league IDs we've already verified this session. */
@@ -18,22 +20,27 @@ const _verified = new Set<string>();
 
 /**
  * Detect the platform from a league ID.
- * ESPN IDs are prefixed with "espn_", everything else is Sleeper.
+ * ESPN IDs are prefixed with "espn_". Yahoo IDs would use "yahoo_" if added.
+ * Plain numeric IDs default to Sleeper (the original platform).
  */
 function detectPlatform(leagueId: string): Platform {
-  return leagueId.startsWith("espn_") ? "espn" : "sleeper";
+  if (leagueId.startsWith("espn_")) return "espn";
+  // Yahoo support not yet implemented — would be "yahoo_" prefixed.
+  return "sleeper";
 }
 
 /**
- * Extract the raw platform league ID (strips the "espn_" prefix for ESPN).
+ * Extract the raw platform league ID (strips the platform prefix).
  */
 function extractPlatformLeagueId(leagueId: string): string {
-  return leagueId.startsWith("espn_") ? leagueId.slice(5) : leagueId;
+  if (leagueId.startsWith("espn_")) return leagueId.slice(5);
+  return leagueId;
 }
 
 /**
  * Hook: call from any page that has a leagueId param.
  * Ensures the Firestore league doc exists (creates a skeleton if not).
+ * Only runs for authenticated users.
  *
  * @param leagueId - The league document ID (may be undefined if param missing)
  * @param leagueName - Optional display name to set on creation
@@ -44,11 +51,10 @@ export function useEnsureLeagueDoc(
   leagueName?: string,
   season?: number
 ): void {
-  const attempted = useRef(false);
+  const { currentUser } = useAuth();
 
   useEffect(() => {
-    if (!leagueId || _verified.has(leagueId) || attempted.current) return;
-    attempted.current = true;
+    if (!leagueId || !currentUser || _verified.has(leagueId)) return;
 
     (async () => {
       try {
@@ -69,9 +75,10 @@ export function useEnsureLeagueDoc(
         }
         _verified.add(leagueId);
       } catch (err) {
-        // Non-fatal — the page still works without the league doc
+        // Non-fatal — the page still works without the league doc.
+        // Don't add to _verified so it can retry on next navigation.
         console.warn("[useEnsureLeagueDoc] Failed to ensure league doc:", err);
       }
     })();
-  }, [leagueId, leagueName, season]);
+  }, [leagueId, leagueName, season, currentUser]);
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import styled, { useTheme } from "styled-components";
 import { leagueIds } from "../components/constants/LeagueConstants";
 import hotDogsData from "../data/hotDogs.json";
 import { useCompletedWeeks } from "../hooks/useCompletedWeeks";
+import { useEnsureLeagueDoc } from "../hooks/useEnsureLeagueDoc";
 
 const GridContainer = styled.div`
   display: grid;
@@ -55,6 +56,7 @@ function Home() {
   const navigate = useNavigate();
   const { leagueId } = useParams();
   const theme = useTheme();
+  useEnsureLeagueDoc(leagueId);
 
   const mainLeagueId = leagueIds.mainLeague;
   const walterPicksLeagueId = leagueIds.walterPicks;

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -193,6 +193,17 @@ const SignInHint = styled.p`
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
+
+/** Map platform type to its emoji icon. */
+function platformIcon(type: string): string {
+  switch (type) {
+    case "sleeper": return "😴";
+    case "espn": return "🏈";
+    case "yahoo": return "🟣";
+    default: return "🏟️";
+  }
+}
+
 function LeaguePicker(): React.ReactElement {
   const navigate = useNavigate();
   const { currentUser, savedLeagues, removeLeague } = useAuth();
@@ -236,7 +247,7 @@ function LeaguePicker(): React.ReactElement {
                   <LeagueName>
                     {league.name} ({league.year})
                   </LeagueName>
-                  <LeagueMeta>{league.type}</LeagueMeta>
+                  <LeagueMeta>{platformIcon(league.type)} {league.type}</LeagueMeta>
                 </LeagueInfo>
                 <RemoveButton
                   onClick={(e) => handleRemoveLeague(e, league.id)}

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -193,14 +193,17 @@ const SignInHint = styled.p`
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
-
 /** Map platform type to its emoji icon. */
 function platformIcon(type: string): string {
   switch (type) {
-    case "sleeper": return "😴";
-    case "espn": return "🏈";
-    case "yahoo": return "🟣";
-    default: return "🏟️";
+    case "sleeper":
+      return "😴";
+    case "espn":
+      return "🏈";
+    case "yahoo":
+      return "🟣";
+    default:
+      return "🏟️";
   }
 }
 
@@ -247,7 +250,9 @@ function LeaguePicker(): React.ReactElement {
                   <LeagueName>
                     {league.name} ({league.year})
                   </LeagueName>
-                  <LeagueMeta>{platformIcon(league.type)} {league.type}</LeagueMeta>
+                  <LeagueMeta>
+                    {platformIcon(league.type)} {league.type}
+                  </LeagueMeta>
                 </LeagueInfo>
                 <RemoveButton
                   onClick={(e) => handleRemoveLeague(e, league.id)}

--- a/src/utils/refreshSleeperLeagues.ts
+++ b/src/utils/refreshSleeperLeagues.ts
@@ -8,42 +8,53 @@
  * Only touches Sleeper leagues — ESPN/Yahoo leagues are left untouched.
  */
 import { getNflState } from "./api/SleeperAPI";
-import {
-  getUserProfile,
-  updateUserProfile,
-  SavedLeague,
-} from "./survivorUtils";
+import { updateUserProfile, SavedLeague } from "./survivorUtils";
 
 /** Cooldown: skip refresh if we already ran within this window (ms). */
 const REFRESH_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 let _lastRefreshMs = 0;
 
 /**
+ * Sleeper league shape from the API (subset of fields we care about).
+ */
+interface SleeperLeagueResponse {
+  league_id: string;
+  name: string;
+  avatar: string | null;
+}
+
+/**
  * Fetch the user's current-season Sleeper leagues and merge them into their
  * saved leagues list. Only writes to Firestore if something changed.
  *
+ * Accepts the already-loaded profile data to avoid a redundant Firestore read.
+ *
  * @param userId - Firebase Auth UID
+ * @param sleeperUserId - The linked Sleeper user ID (skip if not linked)
+ * @param currentLeagues - The user's currently saved leagues from profile
  * @param setSavedLeagues - React state setter for the saved leagues array
  */
 export async function refreshSleeperLeagues(
   userId: string,
+  sleeperUserId: string | undefined,
+  currentLeagues: SavedLeague[],
   setSavedLeagues: React.Dispatch<React.SetStateAction<SavedLeague[]>>
 ): Promise<void> {
   try {
+    // Skip if no Sleeper account linked
+    if (!sleeperUserId) return;
+
     // Cooldown check — don't hammer the API on rapid re-renders
     if (Date.now() - _lastRefreshMs < REFRESH_COOLDOWN_MS) return;
     _lastRefreshMs = Date.now();
 
-    const profile = await getUserProfile(userId);
-    if (!profile?.sleeperUserId) return;
-
     const nflState = await getNflState();
     const res = await fetch(
-      `https://api.sleeper.app/v1/user/${profile.sleeperUserId}/leagues/nfl/${nflState.season}`
+      `https://api.sleeper.app/v1/user/${sleeperUserId}/leagues/nfl/${nflState.season}`
     );
     if (!res.ok) return;
 
-    const apiLeagues: any[] = await res.json();
+    const apiLeagues: SleeperLeagueResponse[] = await res.json();
     const season = parseInt(nflState.season, 10);
 
     // Build the fresh Sleeper league list from the API
@@ -52,21 +63,18 @@ export async function refreshSleeperLeagues(
       type: "sleeper" as const,
       name: lg.name,
       year: season,
-      avatar: lg.avatar
-        ? `https://sleepercdn.com/avatars/${lg.avatar}`
-        : undefined,
+      avatar: lg.avatar ? `https://sleepercdn.com/avatars/${lg.avatar}` : undefined,
     }));
 
     // Keep all non-Sleeper leagues untouched
-    const existing = profile.leagues ?? [];
-    const nonSleeper = existing.filter((l) => l.type !== "sleeper");
+    const nonSleeper = currentLeagues.filter((l) => l.type !== "sleeper");
 
-    // Detect if anything actually changed (compare IDs + names + avatars)
-    const existingSleeper = existing.filter((l) => l.type === "sleeper");
+    // Detect if anything actually changed (compare IDs, names, avatars, year)
+    const existingSleeper = currentLeagues.filter((l) => l.type === "sleeper");
     const serialize = (leagues: SavedLeague[]) =>
       JSON.stringify(
         leagues
-          .map((l) => ({ id: l.id, name: l.name, avatar: l.avatar }))
+          .map((l) => ({ id: l.id, name: l.name, avatar: l.avatar, year: l.year }))
           .sort((a, b) => a.id.localeCompare(b.id))
       );
 
@@ -83,6 +91,8 @@ export async function refreshSleeperLeagues(
     // Update local state so the UI re-renders
     setSavedLeagues(merged);
   } catch (err) {
+    // Reset cooldown so we can retry on next auth cycle
+    _lastRefreshMs = 0;
     // Non-fatal — cached leagues still work
     console.warn("[refreshSleeperLeagues] Background refresh failed:", err);
   }

--- a/src/utils/refreshSleeperLeagues.ts
+++ b/src/utils/refreshSleeperLeagues.ts
@@ -1,0 +1,89 @@
+/**
+ * refreshSleeperLeagues — background sync of Sleeper leagues.
+ *
+ * Called fire-and-forget after the cached profile loads. Fetches the user's
+ * current-season leagues from the Sleeper API, diffs against saved leagues,
+ * and writes changes to Firestore + updates local state.
+ *
+ * Only touches Sleeper leagues — ESPN/Yahoo leagues are left untouched.
+ */
+import { getNflState } from "./api/SleeperAPI";
+import {
+  getUserProfile,
+  updateUserProfile,
+  SavedLeague,
+} from "./survivorUtils";
+
+/** Cooldown: skip refresh if we already ran within this window (ms). */
+const REFRESH_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+let _lastRefreshMs = 0;
+
+/**
+ * Fetch the user's current-season Sleeper leagues and merge them into their
+ * saved leagues list. Only writes to Firestore if something changed.
+ *
+ * @param userId - Firebase Auth UID
+ * @param setSavedLeagues - React state setter for the saved leagues array
+ */
+export async function refreshSleeperLeagues(
+  userId: string,
+  setSavedLeagues: React.Dispatch<React.SetStateAction<SavedLeague[]>>
+): Promise<void> {
+  try {
+    // Cooldown check — don't hammer the API on rapid re-renders
+    if (Date.now() - _lastRefreshMs < REFRESH_COOLDOWN_MS) return;
+    _lastRefreshMs = Date.now();
+
+    const profile = await getUserProfile(userId);
+    if (!profile?.sleeperUserId) return;
+
+    const nflState = await getNflState();
+    const res = await fetch(
+      `https://api.sleeper.app/v1/user/${profile.sleeperUserId}/leagues/nfl/${nflState.season}`
+    );
+    if (!res.ok) return;
+
+    const apiLeagues: any[] = await res.json();
+    const season = parseInt(nflState.season, 10);
+
+    // Build the fresh Sleeper league list from the API
+    const freshSleeper: SavedLeague[] = apiLeagues.map((lg) => ({
+      id: lg.league_id,
+      type: "sleeper" as const,
+      name: lg.name,
+      year: season,
+      avatar: lg.avatar
+        ? `https://sleepercdn.com/avatars/${lg.avatar}`
+        : undefined,
+    }));
+
+    // Keep all non-Sleeper leagues untouched
+    const existing = profile.leagues ?? [];
+    const nonSleeper = existing.filter((l) => l.type !== "sleeper");
+
+    // Detect if anything actually changed (compare IDs + names + avatars)
+    const existingSleeper = existing.filter((l) => l.type === "sleeper");
+    const serialize = (leagues: SavedLeague[]) =>
+      JSON.stringify(
+        leagues
+          .map((l) => ({ id: l.id, name: l.name, avatar: l.avatar }))
+          .sort((a, b) => a.id.localeCompare(b.id))
+      );
+
+    if (serialize(existingSleeper) === serialize(freshSleeper)) {
+      // No changes — skip the Firestore write
+      return;
+    }
+
+    const merged = [...nonSleeper, ...freshSleeper];
+
+    // Persist to Firestore
+    await updateUserProfile(userId, { leagues: merged });
+
+    // Update local state so the UI re-renders
+    setSavedLeagues(merged);
+  } catch (err) {
+    // Non-fatal — cached leagues still work
+    console.warn("[refreshSleeperLeagues] Background refresh failed:", err);
+  }
+}


### PR DESCRIPTION
## Goal
Implement the core pieces of #52 (View your leagues dashboard).

## Approach
Three focused changes, all building on the existing LeaguePicker UI:

### 1. Background Sleeper league refresh
- After cached leagues load from Firestore (instant), fires off a background fetch to `/v1/user/{id}/leagues/nfl/{season}`
- Diffs against saved Sleeper leagues — only writes to Firestore if something changed
- Non-Sleeper leagues (ESPN, Yahoo) are untouched during merge
- 1-hour cooldown prevents hammering the API on re-renders
- New file: `src/utils/refreshSleeperLeagues.ts`

### 2. Platform icons on league cards
- Adds emoji icons next to the platform label (😴 Sleeper, 🏈 ESPN, 🟣 Yahoo)
- Minimal change to LeaguePicker.tsx

### 3. Auto-create Firestore league docs
- `useEnsureLeagueDoc` hook — called from Home.jsx (league landing page)
- On first visit, checks if `/leagues/{leagueId}` exists; creates a skeleton doc if not
- In-memory set avoids redundant Firestore reads within a session
- Sets the foundation for #53 (editor role claiming)
- New file: `src/hooks/useEnsureLeagueDoc.ts`

## Key Changes
| File | Change |
|---|---|
| `src/utils/refreshSleeperLeagues.ts` | New — background Sleeper league sync |
| `src/contexts/AuthContext.tsx` | Import + fire-and-forget call after profile loads |
| `src/hooks/useEnsureLeagueDoc.ts` | New — auto-create league doc hook |
| `src/pages/Home.jsx` | Import + call `useEnsureLeagueDoc` |
| `src/pages/LeaguePicker.tsx` | Platform emoji icons on league cards |

## Testing
- TypeScript compiles clean (`tsc --noEmit` passes)
- Production build passes (`pnpm build`)
- Refresh logic: only writes when diffs detected, cooldown prevents excessive API calls
- `useEnsureLeagueDoc`: only reads once per league per session, only writes if doc missing

## Risk Level
Low — additive changes, no existing behavior modified. Background refresh is fire-and-forget with full error handling.

Refs #52