### PR TITLE
Phase 1: Firestore league docs on first access + editor status on dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,5 +27,7 @@ REACT_APP_YAHOO_CLIENT_ID=
 # Set to 1 to point Auth + Firestore at local emulators instead of prod.
 # Start the emulators first in a separate terminal: pnpm emulators
 # Emulator UI: http://localhost:4000
+# Data (fake accounts, league docs) persists across restarts in
+# .emulator-data/ (gitignored) — delete that folder for a clean slate.
 # -------------------------------------------------------------------
 # REACT_APP_USE_EMULATOR=1

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,11 @@ REACT_APP_YAHOO_CLIENT_ID=
 # Optional: enable per-section performance timing in the newsletter (dev only).
 # Sections taking >200ms will emit a console.warn.
 # REACT_APP_NEWSLETTER_PERF=1
+
+# -------------------------------------------------------------------
+# Firebase Local Emulator Suite (dev only)
+# Set to 1 to point Auth + Firestore at local emulators instead of prod.
+# Start the emulators first in a separate terminal: pnpm emulators
+# Emulator UI: http://localhost:4000
+# -------------------------------------------------------------------
+# REACT_APP_USE_EMULATOR=1

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 /oldNews
 src/newsletters/2023 Week 12
 .claude/settings.local.json
+.emulator-data

--- a/aigen/technical_considerations.md
+++ b/aigen/technical_considerations.md
@@ -38,7 +38,7 @@ This document captures lessons learned and important notes for The Offensive Lin
 - **Conditional Rendering:** Check both `status !== "success"` AND data presence to show sections while loading
 - **Bundle Size:** Chart components (Victory.js) are now lazy-loaded via `React.lazy` — chunks load on demand after data arrives. The static imports for tableStyles/newsStyles are kept synchronous since they're small.
 - **ErrorBoundary Retry Test Pattern:** When testing retry in an error boundary, update child props via `rerender` BEFORE clicking Retry — otherwise the reset triggers a re-render of the still-throwing child and the boundary immediately re-enters error state
-- **No `@testing-library/jest-dom`:** Project has no `setupTests` file — use `.toBeTruthy()` instead of `.toBeInTheDocument()`, and `.toBeNull()` instead of `.not.toBeInTheDocument()`
+- **`src/setupTests.js` exists (added Jul 2026):** loads `@testing-library/jest-dom` (so `.toBeInTheDocument()` works), polyfills web globals firebase needs under jsdom (TextEncoder, ReadableStream, Blob, etc.), and stubs `window.matchMedia` for ThemeContext
 
 ## Newsletter Stack Architecture
 

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,18 @@
   "firestore": {
     "rules": "firestore.rules"
   },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  },
   "hosting": {
     "public": "build",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css}\" && eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "typecheck": "tsc --noEmit",
-    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css}\""
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css}\"",
+    "emulators": "firebase emulators:start"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css}\" && eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "typecheck": "tsc --noEmit",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css}\"",
-    "emulators": "firebase emulators:start $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data"
+    "emulators": "firebase emulators:start --only auth,firestore $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css}\" && eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "typecheck": "tsc --noEmit",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css}\"",
-    "emulators": "firebase emulators:start"
+    "emulators": "firebase emulators:start $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/newsletter/__tests__/errorCopy.test.ts
+++ b/src/components/newsletter/__tests__/errorCopy.test.ts
@@ -35,7 +35,7 @@ describe("getErrorCopy", () => {
 
   it("returns server error copy for 500 errors", () => {
     const copy = getErrorCopy(new Error("500 Internal Server Error"));
-    expect(copy.title).toMatch(/sleeper api error/i);
+    expect(copy.title).toMatch(/api server error/i);
   });
 
   it("returns parse error copy for JSON errors", () => {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,7 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { getAuth, connectAuthEmulator } from "firebase/auth";
+import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
 // import { getAnalytics } from "firebase/analytics";
 
 // Your web app's Firebase configuration
@@ -20,4 +20,10 @@ const firebaseConfig = {
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+
+// Opt-in local emulators (see .env.example). Ports match firebase.json.
+if (process.env.REACT_APP_USE_EMULATOR === "1") {
+  connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
+  connectFirestoreEmulator(db, "127.0.0.1", 8080);
+}
 // const analytics = getAnalytics(app);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -22,7 +22,9 @@ export const auth = getAuth(app);
 export const db = getFirestore(app);
 
 // Opt-in local emulators (see .env.example). Ports match firebase.json.
-if (process.env.REACT_APP_USE_EMULATOR === "1") {
+// NODE_ENV guard: production builds ignore the flag even if it leaks in
+// via a local .env, so a manual `pnpm build` can never ship emulator URLs.
+if (process.env.NODE_ENV === "development" && process.env.REACT_APP_USE_EMULATOR === "1") {
   connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
   connectFirestoreEmulator(db, "127.0.0.1", 8080);
 }

--- a/src/hooks/useLeagueDoc.ts
+++ b/src/hooks/useLeagueDoc.ts
@@ -1,0 +1,57 @@
+/**
+ * useLeagueDoc — read (and lazily create) the Firestore document for a league.
+ *
+ * Every league viewed on the site gets a /leagues/{leagueId} document that
+ * holds platform-neutral metadata plus editor/privacy state (see issue #52).
+ *
+ * With `createIfMissing: true` (used on league entry pages like Home), the
+ * hook creates the document on first authenticated access, seeding it from
+ * the platform API (league name + season) with an unclaimed editor role.
+ * Anonymous visitors never trigger creation — Firestore rules require auth.
+ *
+ * Without it (used on dashboards), the hook is a plain read: a missing
+ * document simply means no one has visited the league while signed in yet.
+ */
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { useAuth } from "../contexts/AuthContext";
+import { getLeague as getLeagueDoc, createLeague } from "../services/firestoreCrud";
+import {
+  getLeague as getPlatformLeague,
+  getPlatform,
+  getPlatformLeagueId,
+} from "../utils/api/FantasyAPI";
+import type { LeagueDoc } from "../types/firestore";
+
+interface UseLeagueDocOptions {
+  /** Create the Firestore doc on first access when signed in. Default false. */
+  createIfMissing?: boolean;
+}
+
+export function useLeagueDoc(
+  leagueId: string | undefined,
+  { createIfMissing = false }: UseLeagueDocOptions = {}
+): UseQueryResult<LeagueDoc | null> {
+  const { currentUser } = useAuth();
+  const canCreate = createIfMissing && !!currentUser;
+
+  return useQuery<LeagueDoc | null>({
+    // canCreate is in the key so signing in re-runs the query and creates the doc
+    queryKey: ["leagueDoc", leagueId, canCreate],
+    enabled: !!leagueId,
+    queryFn: async () => {
+      const existing = await getLeagueDoc(leagueId!);
+      if (existing || !canCreate) return existing;
+
+      const platformLeague = await getPlatformLeague(leagueId!);
+      await createLeague(leagueId!, {
+        platform: getPlatform(leagueId!),
+        platformLeagueId: getPlatformLeagueId(leagueId!),
+        name: platformLeague.name,
+        season: parseInt(platformLeague.season, 10),
+        editorUid: null,
+        coEditorUids: [],
+      });
+      return getLeagueDoc(leagueId!);
+    },
+  });
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import styled, { useTheme } from "styled-components";
 import { leagueIds } from "../components/constants/LeagueConstants";
 import hotDogsData from "../data/hotDogs.json";
 import { useCompletedWeeks } from "../hooks/useCompletedWeeks";
+import { useLeagueDoc } from "../hooks/useLeagueDoc";
 
 const GridContainer = styled.div`
   display: grid;
@@ -62,6 +63,10 @@ function Home() {
   const isMainLeague = leagueId === mainLeagueId;
 
   const { completedWeeksDesc: recapWeekButtons } = useCompletedWeeks(leagueId, !isMainLeague);
+
+  // Ensure the /leagues/{leagueId} Firestore doc exists (created on first
+  // authenticated visit; anonymous visits are read-only).
+  useLeagueDoc(leagueId, { createIfMissing: true });
 
   // Function to get MotW loser info for a newsletter issue
   const getMotWLoserInfo = (issueName) => {

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -15,6 +15,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useAuth } from "../contexts/AuthContext";
+import { useLeagueDoc } from "../hooks/useLeagueDoc";
 import type { SavedLeague } from "../utils/survivorUtils";
 
 /* ------------------------------------------------------------------ */
@@ -181,6 +182,12 @@ const RemoveButton = styled.button`
   }
 `;
 
+const EditorStatus = styled.span<{ $isYou?: boolean }>`
+  font-size: 12px;
+  color: ${({ theme, $isYou }: any) => ($isYou ? theme.newsBlue : theme.text)};
+  opacity: ${({ $isYou }: { $isYou?: boolean }) => ($isYou ? 1 : 0.5)};
+`;
+
 const SignInHint = styled.p`
   font-size: 13px;
   color: ${({ theme }: any) => theme.text};
@@ -192,6 +199,25 @@ const SignInHint = styled.p`
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
+
+/**
+ * Editor status line for a saved league card: unclaimed / claimed / yours.
+ * A missing league doc means no one has visited the league signed-in yet,
+ * which is equivalent to the editor role being unclaimed.
+ */
+function EditorStatusLine({ leagueId }: { leagueId: string }): React.ReactElement | null {
+  const { currentUser } = useAuth();
+  const { data: leagueDoc, isLoading } = useLeagueDoc(leagueId);
+
+  if (isLoading) return null;
+  if (!leagueDoc || leagueDoc.editorUid === null) {
+    return <EditorStatus>Editor role unclaimed</EditorStatus>;
+  }
+  if (currentUser && leagueDoc.editorUid === currentUser.uid) {
+    return <EditorStatus $isYou>You're the editor</EditorStatus>;
+  }
+  return <EditorStatus>Editor claimed</EditorStatus>;
+}
 
 function LeaguePicker(): React.ReactElement {
   const navigate = useNavigate();
@@ -237,6 +263,7 @@ function LeaguePicker(): React.ReactElement {
                     {league.name} ({league.year})
                   </LeagueName>
                   <LeagueMeta>{league.type}</LeagueMeta>
+                  <EditorStatusLine leagueId={league.id} />
                 </LeagueInfo>
                 <RemoveButton
                   onClick={(e) => handleRemoveLeague(e, league.id)}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,39 @@
+// Adds matchers like .toBeInTheDocument() used by LeagueWeeklyRecap tests.
+import "@testing-library/jest-dom";
+
+// Jest runs in jsdom, which lacks several web globals that firebase (via
+// undici) needs at import time. Node has native implementations of all of
+// them — copy them onto the jsdom global.
+const { TextEncoder, TextDecoder } = require("util");
+const { ReadableStream, WritableStream, TransformStream } = require("stream/web");
+const { MessageChannel, MessagePort } = require("worker_threads");
+const { Blob } = require("buffer");
+
+// jsdom has no matchMedia; ThemeContext calls it for prefers-color-scheme.
+if (typeof window !== "undefined" && typeof window.matchMedia === "undefined") {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+for (const [name, impl] of Object.entries({
+  TextEncoder,
+  TextDecoder,
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+  MessageChannel,
+  MessagePort,
+  Blob,
+})) {
+  if (typeof global[name] === "undefined") {
+    global[name] = impl;
+  }
+}

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -8,7 +8,8 @@
  *   /leagues/{leagueId}/newsletters/{weekNumber}
  *   /leagues/{leagueId}/weekData/{weekNumber}
  *
- * leagueId format: plain numeric for Sleeper, "espn_XXXXX" for ESPN.
+ * leagueId format: plain numeric for Sleeper, "espn_XXXXX" for ESPN,
+ * "yahoo_XXXXX" for Yahoo.
  * platformLeagueId = raw ID as used by the platform's own API.
  *
  * NOTE: ESPN credentials (espn_s2 / SWID) are NEVER stored in Firestore.
@@ -20,10 +21,10 @@
 import { Timestamp } from "firebase/firestore";
 
 /** Supported fantasy platforms. */
-export type Platform = "sleeper" | "espn";
+export type Platform = "sleeper" | "espn" | "yahoo";
 
 /** Privacy setting for a league. Defaults to 'public' for Phase 1. */
-export type Privacy = "public" | "private";
+export type Privacy = "public" | "league_only";
 
 /** Newsletter publication status. */
 export type NewsletterStatus = "draft" | "published";
@@ -65,8 +66,8 @@ export interface LeagueDoc {
   name: string;
   /** NFL season year (e.g. 2025). */
   season: number;
-  /** Firebase UID of the primary editor. */
-  editorUid: string;
+  /** Firebase UID of the primary editor. Null until a member claims the role. */
+  editorUid: string | null;
   /** Firebase UIDs of co-editors who can also edit newsletters. */
   coEditorUids: string[];
   /** Privacy setting. Defaults to 'public' for Phase 1. */

--- a/src/utils/api/FantasyAPI.ts
+++ b/src/utils/api/FantasyAPI.ts
@@ -53,6 +53,22 @@ function isYahoo(leagueId: string): boolean {
 }
 
 /**
+ * Derive the platform from a namespaced league ID.
+ */
+export function getPlatform(leagueId: string): "sleeper" | "espn" | "yahoo" {
+  if (isYahoo(leagueId)) return "yahoo";
+  if (isEspn(leagueId)) return "espn";
+  return "sleeper";
+}
+
+/**
+ * Strip the platform prefix, returning the raw ID used by the platform's own API.
+ */
+export function getPlatformLeagueId(leagueId: string): string {
+  return leagueId.replace(/^(espn_|yahoo_)/, "");
+}
+
+/**
  * Fetch league metadata.
  */
 export const getLeague = async (leagueId: string): Promise<League> => {


### PR DESCRIPTION
Closes #52

## What this does

- **Emulator support (opt-in):** `pnpm emulators` starts the Firebase Local Emulator Suite (Auth + Firestore, UI on :4000); set `REACT_APP_USE_EMULATOR=1` in `.env` to point the app at it instead of prod. Ports live in `firebase.json`.
- **`useLeagueDoc` hook:** reads `/leagues/{leagueId}`; with `createIfMissing` (used on the league Home page) it creates the doc on first authenticated visit, seeded from the platform API — `platform`, `platformLeagueId`, `name`, `season`, `editorUid: null`, `coEditorUids: []`, `privacy: 'public'`. Anonymous visits never write (Firestore rules require auth for create).
- **Dashboard editor status:** each saved league on the LeaguePicker shows "Editor role unclaimed" / "Editor claimed" / "You're the editor" (a missing doc displays as unclaimed).
- **Schema fixes while instantiating it for the first time:** `editorUid` is nullable until claimed (needed for #53), `Platform` includes `yahoo` (adapter already exists), `Privacy` uses `league_only` to match #85.
- **Test suite revival:** the Jest suite had been silently broken (CI only runs lint/typecheck/format). Added `src/setupTests.js` — jsdom polyfills for firebase (TextEncoder, ReadableStream, Blob, …), a `matchMedia` stub for ThemeContext, and loads `@testing-library/jest-dom` (already a dependency, never loaded). Fixed one stale assertion from the Sleeper→multi-platform copy rename.

## Testing

- `pnpm test`: **121/121 passing, 9/9 suites** (baseline before this branch: 17 passing, 8 suites failing to run)
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all clean

## Manual verification steps

1. `pnpm emulators` in one terminal; `.env` with `REACT_APP_USE_EMULATOR=1`; `pnpm start` in another
2. Sign in with Google (emulator offers a fake-account flow), visit any league via the picker → check the Emulator UI (http://localhost:4000) for the created `/leagues/{leagueId}` doc
3. Back on the league picker, saved leagues should show "Editor role unclaimed"
4. While signed out, visit a league that has no doc → no doc created, no errors in console

## Out of scope (next up)

- #53 editor claiming — needs a Firestore rules change to allow the unclaimed→claimed transition (`editorUid == null && request.resource.data.editorUid == request.auth.uid`); rules currently make unclaimed leagues unclaimable

🤖 Generated with [Claude Code](https://claude.com/claude-code)