### PR TITLE
feat: reliable Sleeper league saving — discovery fix, save-on-click, background sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 src/newsletters/2023 Week 12
 .claude/settings.local.json
 .emulator-data
+firebase-debug.log
+firestore-debug.log

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -18,7 +18,12 @@ import {
   UserProfile,
   SavedLeague,
 } from "../utils/survivorUtils";
-import { getSleeperUserByUsername, getNflState } from "../utils/api/SleeperAPI";
+import { getSleeperUserByUsername } from "../utils/api/SleeperAPI";
+import {
+  discoverSleeperLeagues,
+  mergeSleeperLeagues,
+  refreshSleeperLeagues,
+} from "../utils/sleeperLeagueSync";
 
 interface AuthContextType {
   currentUser: FirebaseUser | null;
@@ -49,10 +54,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const auth = getAuth(app);
 
   const loadProfile = useCallback(
-    async (userId: string) => {
+    async (userId: string): Promise<UserProfile | null> => {
       setLoadingProfile(true);
       let userProfile = await getUserProfile(userId);
       const currentEmail = currentUser?.email || "";
+      let loadedProfile: UserProfile | null = null;
       if (!userProfile && currentUser?.displayName) {
         // Create profile with Google display name and email if it doesn't exist
         const newProfile = {
@@ -62,14 +68,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         await setUserProfile(userId, newProfile);
         setProfile(newProfile);
         setSavedLeagues([]);
+        loadedProfile = newProfile;
       } else if (userProfile) {
         // Update existing profile if email is missing or different
         if (!userProfile.email || userProfile.email !== currentEmail) {
           const updatedProfile = { ...userProfile, email: currentEmail };
           await updateUserProfile(userId, { email: currentEmail });
           setProfile(updatedProfile);
+          loadedProfile = updatedProfile;
         } else {
           setProfile(userProfile);
+          loadedProfile = userProfile;
         }
         setSavedLeagues(userProfile.leagues ?? []);
       } else {
@@ -77,6 +86,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setSavedLeagues([]);
       }
       setLoadingProfile(false);
+      return loadedProfile;
     },
     [currentUser?.displayName, currentUser?.email]
   );
@@ -85,7 +95,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setCurrentUser(user);
       if (user) {
-        await loadProfile(user.uid);
+        const loadedProfile = await loadProfile(user.uid);
+        // Background sync of Sleeper leagues — fire-and-forget, additive only
+        refreshSleeperLeagues(user.uid, loadedProfile).then((merged) => {
+          if (merged) setSavedLeagues(merged);
+        });
         setLoading(false);
       } else {
         setProfile(null);
@@ -160,7 +174,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   /**
    * Link a Sleeper account by username. Validates the username against the
    * Sleeper API, persists sleeperUserId/sleeperUsername to Firestore, and
-   * auto-saves the user's current-season leagues to savedLeagues.
+   * auto-saves the user's leagues (current + previous season) to savedLeagues.
    */
   const linkSleeper = async (username: string): Promise<{ success: boolean; error?: string }> => {
     if (!currentUser) return { success: false, error: "Not signed in" };
@@ -179,21 +193,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     setProfile((prev) => (prev ? { ...prev, ...updates } : null));
 
-    // Auto-discover leagues for the current season (non-fatal if it fails)
+    // Auto-discover leagues (non-fatal if it fails). Additive merge in a
+    // single Firestore write; respects leagues the user removed.
     try {
-      const nflState = await getNflState();
-      const res = await fetch(
-        `https://api.sleeper.app/v1/user/${sleeperUser.user_id}/leagues/nfl/${nflState.season}`
+      const fresh = await discoverSleeperLeagues(sleeperUser.user_id);
+      const { merged, changed } = mergeSleeperLeagues(
+        savedLeagues,
+        fresh,
+        profile?.removedLeagueIds ?? []
       );
-      const leagues: any[] = res.ok ? await res.json() : [];
-      for (const league of leagues) {
-        await addLeague({
-          id: league.league_id,
-          type: "sleeper",
-          name: league.name,
-          year: parseInt(nflState.season, 10),
-          avatar: league.avatar ? `https://sleepercdn.com/avatars/${league.avatar}` : undefined,
-        });
+      if (changed) {
+        const savedOk = await updateUserProfile(currentUser.uid, { leagues: merged });
+        if (savedOk) setSavedLeagues(merged);
       }
     } catch {
       // Linking succeeded even if league discovery fails

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -200,6 +200,20 @@ const SignInHint = styled.p`
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
+/** Map platform type to its emoji icon (matches the platform picker cards). */
+function platformIcon(type: string): string {
+  switch (type) {
+    case "sleeper":
+      return "😴";
+    case "espn":
+      return "🏈";
+    case "yahoo":
+      return "🟣";
+    default:
+      return "🏟️";
+  }
+}
+
 /**
  * Editor status line for a saved league card: unclaimed / claimed / yours.
  * A missing league doc means no one has visited the league signed-in yet,
@@ -262,7 +276,9 @@ function LeaguePicker(): React.ReactElement {
                   <LeagueName>
                     {league.name} ({league.year})
                   </LeagueName>
-                  <LeagueMeta>{league.type}</LeagueMeta>
+                  <LeagueMeta>
+                    {platformIcon(league.type)} {league.type}
+                  </LeagueMeta>
                   <EditorStatusLine leagueId={league.id} />
                 </LeagueInfo>
                 <RemoveButton

--- a/src/pages/SleeperLogin.jsx
+++ b/src/pages/SleeperLogin.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { getNflState } from "../utils/api/SleeperAPI";
+import { getNflState, getSleeperUserByUsername, getUserLeagues } from "../utils/api/SleeperAPI";
+import { toSavedLeague } from "../utils/sleeperLeagueSync";
+import { useAuth } from "../contexts/AuthContext";
 
 const Container = styled.div`
   display: flex;
@@ -81,6 +83,7 @@ function SleeperLogin() {
   const [userId, setUserId] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
   const navigate = useNavigate();
+  const { currentUser, addLeague } = useAuth();
 
   useEffect(() => {
     localStorage.removeItem("selectedLeagueId");
@@ -100,11 +103,7 @@ function SleeperLogin() {
     }
   }, [navigate]);
 
-  const fetchLeaguesForYear = async (uid, year) => {
-    const response = await fetch(`https://api.sleeper.app/v1/user/${uid}/leagues/nfl/${year}`);
-    const data = await response.json();
-    return Array.isArray(data) ? data : [];
-  };
+  const fetchLeaguesForYear = (uid, year) => getUserLeagues(uid, year);
 
   const handleUsernameSubmit = async () => {
     setIsButtonDisabled(true);
@@ -120,8 +119,7 @@ function SleeperLogin() {
     localStorage.setItem("sleeperUsername", username);
 
     try {
-      const userResponse = await fetch(`https://api.sleeper.app/v1/user/${username}`);
-      const userData = await userResponse.json();
+      const userData = await getSleeperUserByUsername(username);
       const uid = userData?.user_id;
 
       if (!uid) {
@@ -226,6 +224,10 @@ function SleeperLogin() {
   const handleLeagueSelect = (league) => {
     localStorage.setItem("selectedLeagueId", league.league_id);
     window.dispatchEvent(new Event("leagueChange"));
+    // Signed-in users get the league saved to their dashboard (fire-and-forget)
+    if (currentUser) {
+      addLeague(toSavedLeague(league));
+    }
     navigate(`/home/${league.league_id}`, { state: { league } });
   };
 

--- a/src/utils/__tests__/sleeperLeagueSync.test.ts
+++ b/src/utils/__tests__/sleeperLeagueSync.test.ts
@@ -1,0 +1,84 @@
+import { toSavedLeague, mergeSleeperLeagues } from "../sleeperLeagueSync";
+import type { SavedLeague } from "../survivorUtils";
+
+describe("toSavedLeague", () => {
+  it("converts a Sleeper league with an avatar", () => {
+    const saved = toSavedLeague({
+      league_id: "123",
+      name: "Test League",
+      season: "2025",
+      avatar: "abc123",
+    });
+    expect(saved).toEqual({
+      id: "123",
+      type: "sleeper",
+      name: "Test League",
+      year: 2025,
+      avatar: "https://sleepercdn.com/avatars/abc123",
+    });
+  });
+
+  it("omits the avatar key entirely when avatar is null (Firestore rejects undefined)", () => {
+    const saved = toSavedLeague({
+      league_id: "456",
+      name: "No Avatar League",
+      season: "2026",
+      avatar: null,
+    });
+    expect("avatar" in saved).toBe(false);
+    expect(saved).toEqual({ id: "456", type: "sleeper", name: "No Avatar League", year: 2026 });
+  });
+});
+
+describe("mergeSleeperLeagues", () => {
+  const sleeper2025: SavedLeague = { id: "s25", type: "sleeper", name: "Old League", year: 2025 };
+  const sleeper2026: SavedLeague = { id: "s26", type: "sleeper", name: "New League", year: 2026 };
+  const espnLeague: SavedLeague = { id: "espn_1", type: "espn", name: "ESPN League", year: 2025 };
+
+  it("adds newly discovered leagues", () => {
+    const { merged, changed } = mergeSleeperLeagues([espnLeague], [sleeper2026]);
+    expect(changed).toBe(true);
+    expect(merged).toEqual([espnLeague, sleeper2026]);
+  });
+
+  it("never deletes leagues missing from the fresh list (past seasons survive a refresh)", () => {
+    const { merged, changed } = mergeSleeperLeagues([sleeper2025, espnLeague], [sleeper2026]);
+    expect(merged).toContainEqual(sleeper2025);
+    expect(merged).toContainEqual(espnLeague);
+    expect(merged).toContainEqual(sleeper2026);
+    expect(changed).toBe(true);
+  });
+
+  it("does not re-add leagues the user removed", () => {
+    const { merged, changed } = mergeSleeperLeagues([], [sleeper2026], ["s26"]);
+    expect(merged).toEqual([]);
+    expect(changed).toBe(false);
+  });
+
+  it("updates metadata of an already-saved league", () => {
+    const renamed = { ...sleeper2026, name: "Renamed League" };
+    const { merged, changed } = mergeSleeperLeagues([sleeper2026], [renamed]);
+    expect(changed).toBe(true);
+    expect(merged).toEqual([renamed]);
+  });
+
+  it("reports no change when fresh data matches saved data", () => {
+    const { merged, changed } = mergeSleeperLeagues([sleeper2026, espnLeague], [sleeper2026]);
+    expect(changed).toBe(false);
+    expect(merged).toEqual([sleeper2026, espnLeague]);
+  });
+
+  it("does not confuse a non-sleeper league with the same id", () => {
+    const weird: SavedLeague = { id: "s26", type: "espn", name: "Same ID ESPN", year: 2026 };
+    const { merged } = mergeSleeperLeagues([weird], [sleeper2026]);
+    // ESPN entry untouched; sleeper league appended separately
+    expect(merged).toContainEqual(weird);
+    expect(merged).toContainEqual(sleeper2026);
+  });
+
+  it("handles empty fresh list without changes", () => {
+    const { merged, changed } = mergeSleeperLeagues([sleeper2025], []);
+    expect(changed).toBe(false);
+    expect(merged).toEqual([sleeper2025]);
+  });
+});

--- a/src/utils/api/SleeperAPI.ts
+++ b/src/utils/api/SleeperAPI.ts
@@ -54,6 +54,37 @@ export const getSleeperUserByUsername = async (
   }
 };
 
+/**
+ * Subset of the Sleeper league shape returned by the user-leagues endpoint
+ * that league-saving features care about.
+ */
+export interface SleeperUserLeague {
+  league_id: string;
+  name: string;
+  season: string;
+  avatar: string | null;
+}
+
+/**
+ * Fetch all leagues a Sleeper user belongs to for a given season.
+ * Returns [] on any failure — callers treat league discovery as best-effort.
+ */
+export const getUserLeagues = async (
+  userId: string,
+  season: string | number
+): Promise<SleeperUserLeague[]> => {
+  try {
+    const data = await dedupedFetch<SleeperUserLeague[]>(
+      `${BASE_URL}/user/${userId}/leagues/nfl/${season}`,
+      "Failed to fetch user leagues"
+    );
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.error("Error fetching user leagues:", error);
+    return [];
+  }
+};
+
 // Function to get league
 export const getLeague = async (leagueId: string): Promise<League> => {
   try {

--- a/src/utils/sleeperLeagueSync.ts
+++ b/src/utils/sleeperLeagueSync.ts
@@ -1,0 +1,121 @@
+/**
+ * sleeperLeagueSync — converting and merging Sleeper leagues into the user's
+ * saved-leagues list.
+ *
+ * Design rules (learned from the reverted PR #83):
+ *   - Merging is ADDITIVE: we update metadata of already-saved leagues and add
+ *     newly discovered ones, but never delete. Users may save leagues they
+ *     browsed but don't belong to, and past-season leagues must survive a
+ *     current-season refresh.
+ *   - Leagues the user explicitly removed (tracked in
+ *     profile.removedLeagueIds) are never re-added by discovery.
+ *   - A missing avatar is OMITTED from the SavedLeague object — Firestore
+ *     rejects `undefined` field values, which silently broke league saving
+ *     for avatar-less leagues (fresh season renewals).
+ */
+import { getNflState, getUserLeagues } from "./api/SleeperAPI";
+import type { SleeperUserLeague } from "./api/SleeperAPI";
+import { updateUserProfile } from "./survivorUtils";
+import type { SavedLeague, UserProfile } from "./survivorUtils";
+
+/** Convert a Sleeper API league to our SavedLeague shape. */
+export function toSavedLeague(league: SleeperUserLeague): SavedLeague {
+  const saved: SavedLeague = {
+    id: league.league_id,
+    type: "sleeper",
+    name: league.name,
+    year: parseInt(league.season, 10),
+  };
+  // Only set avatar when present — `avatar: undefined` makes Firestore throw.
+  if (league.avatar) {
+    saved.avatar = `https://sleepercdn.com/avatars/${league.avatar}`;
+  }
+  return saved;
+}
+
+/**
+ * Additively merge freshly discovered Sleeper leagues into the saved list.
+ * Existing entries get their metadata updated; new ones are appended unless
+ * the user previously removed them. Nothing is ever deleted.
+ */
+export function mergeSleeperLeagues(
+  existing: SavedLeague[],
+  fresh: SavedLeague[],
+  removedLeagueIds: string[] = []
+): { merged: SavedLeague[]; changed: boolean } {
+  const freshById = new Map(fresh.map((l) => [l.id, l]));
+  let changed = false;
+
+  const merged = existing.map((league) => {
+    const update = league.type === "sleeper" ? freshById.get(league.id) : undefined;
+    if (!update) return league;
+    freshById.delete(league.id);
+    const next = { ...league, ...update };
+    if (JSON.stringify(next) !== JSON.stringify(league)) {
+      changed = true;
+      return next;
+    }
+    return league;
+  });
+
+  for (const [id, league] of freshById) {
+    if (removedLeagueIds.includes(id)) continue;
+    merged.push(league);
+    changed = true;
+  }
+
+  return { merged, changed };
+}
+
+/**
+ * Discover the user's Sleeper leagues for the current + previous season.
+ * Two seasons because Sleeper flips to the new season in spring — during the
+ * off-season most of a user's leagues only exist under the previous year.
+ */
+export async function discoverSleeperLeagues(sleeperUserId: string): Promise<SavedLeague[]> {
+  const nflState = await getNflState();
+  const season = parseInt(nflState.season, 10);
+  const [current, previous] = await Promise.all([
+    getUserLeagues(sleeperUserId, season),
+    getUserLeagues(sleeperUserId, season - 1),
+  ]);
+  return [...current, ...previous].map(toSavedLeague);
+}
+
+/** Cooldown so the background refresh doesn't refetch on every page load. */
+const REFRESH_STORAGE_KEY = "sleeperLeaguesRefreshedAt";
+const REFRESH_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Background refresh of the user's Sleeper leagues, called fire-and-forget
+ * after the profile loads. Returns the merged list when something changed
+ * (so the caller can update local state), or null when there's nothing to do.
+ */
+export async function refreshSleeperLeagues(
+  userId: string,
+  profile: UserProfile | null
+): Promise<SavedLeague[] | null> {
+  if (!profile?.sleeperUserId) return null;
+
+  const last = parseInt(localStorage.getItem(REFRESH_STORAGE_KEY) ?? "0", 10);
+  if (Date.now() - last < REFRESH_COOLDOWN_MS) return null;
+
+  try {
+    const fresh = await discoverSleeperLeagues(profile.sleeperUserId);
+    // Only arm the cooldown after a successful fetch so transient failures retry.
+    localStorage.setItem(REFRESH_STORAGE_KEY, String(Date.now()));
+
+    const { merged, changed } = mergeSleeperLeagues(
+      profile.leagues ?? [],
+      fresh,
+      profile.removedLeagueIds ?? []
+    );
+    if (!changed) return null;
+
+    const ok = await updateUserProfile(userId, { leagues: merged });
+    return ok ? merged : null;
+  } catch (error) {
+    console.warn("Sleeper league refresh failed (non-fatal):", error);
+    return null;
+  }
+}

--- a/src/utils/survivorUtils.ts
+++ b/src/utils/survivorUtils.ts
@@ -50,6 +50,8 @@ export interface UserProfile {
   email?: string;
   /** User's saved leagues across platforms */
   leagues?: SavedLeague[];
+  /** League IDs the user explicitly removed — auto-discovery won't re-add these */
+  removedLeagueIds?: string[];
   /** Linked Sleeper account user ID */
   sleeperUserId?: string;
   /** Linked Sleeper account username */
@@ -110,7 +112,10 @@ export const addLeagueToProfile = async (userId: string, league: SavedLeague): P
     // Remove any existing entry with same ID, then append
     const filtered = existing.filter((l) => l.id !== league.id);
     filtered.push(league);
-    return await updateUserProfile(userId, { leagues: filtered });
+    // Manually re-adding a league clears it from the removed list so
+    // auto-discovery can manage it again
+    const removed = (profile?.removedLeagueIds ?? []).filter((id) => id !== league.id);
+    return await updateUserProfile(userId, { leagues: filtered, removedLeagueIds: removed });
   } catch (error) {
     console.error("Error adding league to profile:", error);
     return false;
@@ -132,7 +137,9 @@ export const removeLeagueFromProfile = async (
     const profile = await getUserProfile(userId);
     const existing = profile?.leagues ?? [];
     const filtered = existing.filter((l) => l.id !== leagueId);
-    return await updateUserProfile(userId, { leagues: filtered });
+    // Track the removal so auto-discovery doesn't silently re-add the league
+    const removed = Array.from(new Set([...(profile?.removedLeagueIds ?? []), leagueId]));
+    return await updateUserProfile(userId, { leagues: filtered, removedLeagueIds: removed });
   } catch (error) {
     console.error("Error removing league from profile:", error);
     return false;


### PR DESCRIPTION
Replaces the reverted #83 with safe versions of its features, plus fixes the league-saving bug found while testing #95. Refs #52.

## What this does

- **Fixes silent save failure for avatar-less leagues** — Firestore rejects `undefined` field values, so linking a Sleeper account whose leagues lack avatars (fresh season renewals — i.e. anyone linking in the off-season) saved nothing. `toSavedLeague` now omits the field when absent.
- **Off-season-proof discovery** — linking fetches current + previous season and writes the profile once (previously one write per league, current season only).
- **Save-on-click** — picking a league in the Sleeper browse flow saves it to your dashboard when signed in. Previously there was no UI path that saved a Sleeper league.
- **Background sync without #83's data loss** — on sign-in (1h cooldown), Sleeper leagues sync *additively*: metadata updates, new leagues added, **never deletes** (past-season and browsed leagues survive), and leagues the user removed stay removed via `profile.removedLeagueIds`. Manually re-adding a league clears it from that list.
- **Shared `SleeperAPI.getUserLeagues`** helper replaces raw fetches in `AuthContext` and `SleeperLogin` (with in-flight dedup).
- **Platform emoji icons** on saved-league cards (carried over from #83).

## Testing

- 130/130 tests passing — 9 new unit tests pin the merge rules (never delete, respect removals, no-op when unchanged)
- `typecheck` / `lint` / `format:check` clean
- Verified end-to-end against the emulator: background refresh auto-added past-season leagues; remove → sync doesn't resurrect; browse-click → re-added with removal block cleared; new account + link → avatar-less league saves (the original bug case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)