### PR TITLE
Phase 1: editor role claiming per league

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,10 +27,22 @@ service cloud.firestore {
     // -----------------------------------------------------------------------
     match /leagues/{leagueId} {
       allow read: if true;
-      allow create: if request.auth != null;
+      // Docs are created unclaimed (editorUid null); creating a doc that
+      // names an editor is only allowed if that editor is yourself.
+      allow create: if request.auth != null
+        && (request.resource.data.editorUid == null
+            || request.resource.data.editorUid == request.auth.uid);
       allow update, delete: if request.auth != null
         && (resource.data.editorUid == request.auth.uid
             || request.auth.uid in resource.data.coEditorUids);
+      // One-time claim of an unclaimed editor role: only the editorUid field
+      // may change, and only to the claimer's own UID. First write wins —
+      // a concurrent second claim fails this rule because editorUid is no
+      // longer null.
+      allow update: if request.auth != null
+        && resource.data.editorUid == null
+        && request.resource.data.editorUid == request.auth.uid
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['editorUid']);
 
       // ---------------------------------------------------------------------
       // /leagues/{leagueId}/newsletters/{weekNumber}

--- a/src/components/EditorClaimCard.tsx
+++ b/src/components/EditorClaimCard.tsx
@@ -1,0 +1,143 @@
+/**
+ * EditorClaimCard — banner on a league's home page for the newsletter
+ * editor role (#53).
+ *
+ * States:
+ *   - unclaimed + verified league member  → Claim button
+ *   - unclaimed + signed out              → sign-in prompt
+ *   - unclaimed + Sleeper account not linked → link-account prompt
+ *   - claimed by the current user         → "you're the editor" banner
+ *   - claimed by someone else / not a member / lookup failed → renders nothing
+ *     (the league picker already shows claimed status)
+ */
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../contexts/AuthContext";
+import { useLeagueDoc } from "../hooks/useLeagueDoc";
+import { verifyLeagueMembership, claimEditorRole } from "../utils/leagueClaim";
+import { getPlatform } from "../utils/api/FantasyAPI";
+
+const Card = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 12px 20px 0;
+  padding: 12px 16px;
+  border: 1px solid ${({ theme }) => theme.newsBlue};
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.background};
+`;
+
+const Message = styled.span`
+  color: ${({ theme }) => theme.text};
+  font-size: 15px;
+`;
+
+const ClaimButton = styled.button`
+  background-color: ${({ theme }) => theme.newsBlue};
+  color: ${({ theme }) => theme.background};
+  border: none;
+  border-radius: 20px;
+  padding: 8px 18px;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+`;
+
+const ErrorText = styled.span`
+  color: #bc293d;
+  font-size: 13px;
+  width: 100%;
+  text-align: center;
+`;
+
+interface EditorClaimCardProps {
+  leagueId: string;
+}
+
+function EditorClaimCard({ leagueId }: EditorClaimCardProps): React.ReactElement | null {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { currentUser, profile } = useAuth();
+  // Same options as Home's call so the two share one cached query
+  const { data: leagueDoc, isLoading } = useLeagueDoc(leagueId, { createIfMissing: true });
+  const [claiming, setClaiming] = useState(false);
+  const [claimError, setClaimError] = useState<string | null>(null);
+
+  const unclaimed = !!leagueDoc && leagueDoc.editorUid === null;
+
+  const { data: membership } = useQuery({
+    queryKey: ["leagueMembership", leagueId, profile?.sleeperUserId ?? "none"],
+    queryFn: () => verifyLeagueMembership(leagueId, profile),
+    enabled: !!currentUser && unclaimed,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  if (isLoading || !leagueDoc) return null;
+
+  // Claimed by the current user
+  if (currentUser && leagueDoc.editorUid === currentUser.uid) {
+    return (
+      <Card>
+        <Message>🖋️ You're the editor of this league's newsletter.</Message>
+      </Card>
+    );
+  }
+
+  if (!unclaimed) return null;
+
+  // Unclaimed, signed out — invite sign-in
+  if (!currentUser) {
+    return (
+      <Card>
+        <Message>This league's newsletter editor role is unclaimed.</Message>
+        <ClaimButton onClick={() => navigate("/login")}>Sign in to claim it</ClaimButton>
+      </Card>
+    );
+  }
+
+  // Sleeper league but no linked Sleeper account — point at the profile page
+  if (membership?.reason === "no-sleeper-link" && getPlatform(leagueId) === "sleeper") {
+    return (
+      <Card>
+        <Message>Link your Sleeper account to claim this league's editor role.</Message>
+        <ClaimButton onClick={() => navigate("/profile")}>Go to profile</ClaimButton>
+      </Card>
+    );
+  }
+
+  if (!membership?.isMember) return null;
+
+  const handleClaim = async () => {
+    if (!currentUser) return;
+    setClaiming(true);
+    setClaimError(null);
+    const result = await claimEditorRole(leagueId, currentUser.uid);
+    if (!result.success) {
+      setClaimError(result.error ?? "Something went wrong.");
+    }
+    // Refetch the league doc either way — on failure it shows the new editor
+    await queryClient.invalidateQueries({ queryKey: ["leagueDoc", leagueId] });
+    setClaiming(false);
+  };
+
+  return (
+    <Card>
+      <Message>This league's newsletter editor role is unclaimed.</Message>
+      <ClaimButton onClick={handleClaim} disabled={claiming}>
+        {claiming ? "Claiming…" : "Claim editor role"}
+      </ClaimButton>
+      {claimError && <ErrorText>{claimError}</ErrorText>}
+    </Card>
+  );
+}
+
+export default EditorClaimCard;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,6 +4,7 @@ import { leagueIds } from "../components/constants/LeagueConstants";
 import hotDogsData from "../data/hotDogs.json";
 import { useCompletedWeeks } from "../hooks/useCompletedWeeks";
 import { useLeagueDoc } from "../hooks/useLeagueDoc";
+import EditorClaimCard from "../components/EditorClaimCard";
 
 const GridContainer = styled.div`
   display: grid;
@@ -190,6 +191,7 @@ function Home() {
   return (
     <div>
       {leagueId === mainLeagueId && <BannerImage src="/banner_logo.png" alt="Banner Logo" />}
+      <EditorClaimCard leagueId={leagueId} />
       <GridContainer>
         {/* Default league sections shown for all leagues */}
         {defaultContent.sections.map((section) => (

--- a/src/utils/leagueClaim.ts
+++ b/src/utils/leagueClaim.ts
@@ -1,0 +1,74 @@
+/**
+ * leagueClaim — membership verification and editor-role claiming (#53).
+ *
+ * Membership is verified client-side per the launch plan's MVP approach
+ * (Sleeper has no OAuth; newsletters are low-stakes content):
+ *   - Sleeper: the user's linked sleeperUserId must appear in the league's
+ *     user list.
+ *   - ESPN / Yahoo: successfully fetching the league's users counts —
+ *     private leagues require the user's own credentials to fetch at all.
+ *
+ * Real enforcement of the claim itself lives in firestore.rules: an
+ * unclaimed league (editorUid null) can only transition to the claimer's
+ * own UID, touching no other fields. First write wins.
+ */
+import { getUsers, getPlatform } from "./api/FantasyAPI";
+import { updateLeague } from "../services/firestoreCrud";
+import type { UserProfile } from "./survivorUtils";
+
+export interface MembershipResult {
+  isMember: boolean;
+  /** Why membership failed — used to pick the right UI hint. */
+  reason?: "no-sleeper-link" | "not-in-league" | "fetch-failed";
+}
+
+/**
+ * Check whether the signed-in user is a member of the given league.
+ */
+export async function verifyLeagueMembership(
+  leagueId: string,
+  profile: UserProfile | null
+): Promise<MembershipResult> {
+  if (getPlatform(leagueId) === "sleeper") {
+    if (!profile?.sleeperUserId) {
+      return { isMember: false, reason: "no-sleeper-link" };
+    }
+    try {
+      const users = await getUsers(leagueId);
+      return users.some((u) => u.user_id === profile.sleeperUserId)
+        ? { isMember: true }
+        : { isMember: false, reason: "not-in-league" };
+    } catch {
+      return { isMember: false, reason: "fetch-failed" };
+    }
+  }
+
+  // ESPN / Yahoo: fetching members works ⇒ the user has access to the league
+  try {
+    await getUsers(leagueId);
+    return { isMember: true };
+  } catch {
+    return { isMember: false, reason: "fetch-failed" };
+  }
+}
+
+/**
+ * Claim the editor role for a league. Firestore rules guarantee this only
+ * succeeds while the role is unclaimed — a permission error almost always
+ * means someone else claimed it first.
+ */
+export async function claimEditorRole(
+  leagueId: string,
+  uid: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await updateLeague(leagueId, { editorUid: uid });
+    return { success: true };
+  } catch (error) {
+    console.error("Error claiming editor role:", error);
+    return {
+      success: false,
+      error: "Couldn't claim the editor role — it may have just been claimed by someone else.",
+    };
+  }
+}


### PR DESCRIPTION
Closes #53

## What this does

- **Firestore rules — the claim transition**: an unclaimed league (`editorUid: null`) can be updated to the claimer's own UID, touching only that field (`diff().affectedKeys().hasOnly(['editorUid'])`). First write wins — a concurrent second claim fails because `editorUid` is no longer null. Also tightens `create` so a league doc can't be created naming someone else as editor.
- **Membership verification** (`verifyLeagueMembership`): Sleeper — the user's linked `sleeperUserId` must appear in the league's users list; ESPN/Yahoo — a successful (credentialed) members fetch counts, per the launch plan. A failed lookup never grants membership.
- **EditorClaimCard** on the league home page:
  - unclaimed + verified member → **Claim editor role** button
  - unclaimed + signed out → sign-in prompt
  - unclaimed + Sleeper account not linked → link-account prompt (→ /profile)
  - claimed by you → "🖋️ You're the editor" banner
  - claimed by someone else / not a member → renders nothing (league picker already shows claimed status)

## Scope note

Co-editor appointment is deferred: league members are *platform* users and there's no client-side way to map them to Firebase UIDs without a user directory. #53's own notes say Phase 1 is claim-only; co-editors will ride along with the Phase 2 builder work.

## Testing

Verified end-to-end against the Firebase emulators + real Sleeper API:
- signed-out → sign-in prompt; member account → claim button (membership verified against the real league roster)
- claim click → doc `editorUid` set, banner + league-picker status flip
- unauthenticated direct write to `editorUid` → denied (403) by the new rules
- `pnpm test` 130/130, typecheck/lint/format clean

⚠️ Note for deploy: merging this deploys the updated `firestore.rules` via the existing workflow — required for the claim button to work in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)