### PR TITLE
fix: league avatar placeholder + league row alignment/padding

### DIFF
--- a/src/components/shared/LeagueAvatar.tsx
+++ b/src/components/shared/LeagueAvatar.tsx
@@ -1,0 +1,57 @@
+/**
+ * LeagueAvatar — circular league image with a generic football fallback.
+ *
+ * League rows look inconsistent when some leagues have avatars and others
+ * don't; this renders a 🏈 placeholder circle when there's no image (or the
+ * image fails to load) so every row gets the same layout.
+ *
+ * Extend with styled() to add spacing: styled(LeagueAvatar)`margin-right: 12px;`
+ */
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const Photo = styled.img<{ $size: number }>`
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  border-radius: 50%;
+  flex-shrink: 0;
+`;
+
+const Placeholder = styled.div<{ $size: number }>`
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${({ theme }: any) => theme.neutral3}33;
+  font-size: ${({ $size }) => Math.round($size * 0.55)}px;
+  flex-shrink: 0;
+`;
+
+interface LeagueAvatarProps {
+  /** Image URL; the placeholder shows when absent. */
+  src?: string | null;
+  alt: string;
+  /** Diameter in px. */
+  size?: number;
+  className?: string;
+}
+
+function LeagueAvatar({ src, alt, size = 36, className }: LeagueAvatarProps): React.ReactElement {
+  const [failed, setFailed] = useState(false);
+  useEffect(() => setFailed(false), [src]);
+
+  if (!src || failed) {
+    return (
+      <Placeholder className={className} $size={size} role="img" aria-label={alt}>
+        🏈
+      </Placeholder>
+    );
+  }
+  return (
+    <Photo className={className} $size={size} src={src} alt={alt} onError={() => setFailed(true)} />
+  );
+}
+
+export default LeagueAvatar;

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -126,7 +126,7 @@ const LeagueItem = styled.div`
   background-color: ${({ theme }: any) => theme.background};
   border: 1px solid ${({ theme }: any) => theme.neutral3}44;
   border-radius: 10px;
-  padding: 12px 15px;
+  padding: 16px 18px;
   margin: 8px 0;
   cursor: pointer;
   transition: all 0.15s ease;

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -146,6 +146,7 @@ const LeagueInfo = styled.div`
   align-items: flex-start;
   flex-grow: 1;
   min-width: 0;
+  text-align: left;
 `;
 
 const LeagueName = styled.span`

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useAuth } from "../contexts/AuthContext";
 import { useLeagueDoc } from "../hooks/useLeagueDoc";
+import LeagueAvatar from "../components/shared/LeagueAvatar";
 import type { SavedLeague } from "../utils/survivorUtils";
 
 /* ------------------------------------------------------------------ */
@@ -135,12 +136,8 @@ const LeagueItem = styled.div`
   }
 `;
 
-const LeaguePhoto = styled.img`
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
+const LeaguePhoto = styled(LeagueAvatar)`
   margin-right: 12px;
-  flex-shrink: 0;
 `;
 
 const LeagueInfo = styled.div`
@@ -271,7 +268,7 @@ function LeaguePicker(): React.ReactElement {
           <LeagueList>
             {savedLeagues.map((league) => (
               <LeagueItem key={league.id} onClick={() => handleSelectLeague(league)}>
-                {league.avatar && <LeaguePhoto src={league.avatar} alt={league.name} />}
+                <LeaguePhoto src={league.avatar} alt={league.name} />
                 <LeagueInfo>
                   <LeagueName>
                     {league.name} ({league.year})

--- a/src/pages/SleeperLogin.jsx
+++ b/src/pages/SleeperLogin.jsx
@@ -62,6 +62,7 @@ const LeagueName = styled.span`
   font-size: 18px;
   color: ${({ theme }) => theme.text};
   flex-grow: 1;
+  text-align: left;
 `;
 
 const YearHeader = styled.h3`

--- a/src/pages/SleeperLogin.jsx
+++ b/src/pages/SleeperLogin.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { getNflState, getSleeperUserByUsername, getUserLeagues } from "../utils/api/SleeperAPI";
 import { toSavedLeague } from "../utils/sleeperLeagueSync";
 import { useAuth } from "../contexts/AuthContext";
+import LeagueAvatar from "../components/shared/LeagueAvatar";
 
 const Container = styled.div`
   display: flex;
@@ -53,10 +54,7 @@ const LeagueItem = styled.div`
   justify-content: space-between;
 `;
 
-const LeaguePhoto = styled.img`
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
+const LeaguePhoto = styled(LeagueAvatar)`
   margin-right: 15px;
 `;
 
@@ -272,12 +270,13 @@ function SleeperLogin() {
               <YearHeader>{year} Leagues</YearHeader>
               {leagues.map((league) => (
                 <LeagueItem key={league.league_id} onClick={() => handleLeagueSelect(league)}>
-                  {league.avatar && (
-                    <LeaguePhoto
-                      src={`https://sleepercdn.com/avatars/${league.avatar}`}
-                      alt={league.name}
-                    />
-                  )}
+                  <LeaguePhoto
+                    src={
+                      league.avatar ? `https://sleepercdn.com/avatars/${league.avatar}` : undefined
+                    }
+                    alt={league.name}
+                    size={50}
+                  />
                   <LeagueName>{league.name}</LeagueName>
                 </LeagueItem>
               ))}


### PR DESCRIPTION
## Summary
- New shared `LeagueAvatar` component: leagues without an image get a 🏈 placeholder circle (36px in the picker, 50px in the Sleeper list), and broken avatar URLs fall back to it via `onError`
- Left-align league names: the picker rows and the Sleeper league list both inherited the page's `text-align: center` (the Sleeper list's `flex-grow: 1` name span made it obvious)
- Roomier saved-league rows in the picker (`12px 15px` → `16px 18px`)

## Testing
- Verified headlessly against the dev server: Sleeper list with avatars, signed-in picker rows (emulator account + saved league), and the placeholder path by blocking the Sleeper avatar CDN
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `CI=true pnpm test` (130 passing) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)