### PR TITLE
feat: per-league feature flags on LeagueDoc (closes #94)

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,8 +14,18 @@ import Brightness4Icon from "@mui/icons-material/Brightness4";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
 import AccountCircle from "@mui/icons-material/AccountCircle";
 import { useTheme } from "../ThemeContext";
-import { leagueIds } from "./constants/LeagueConstants";
 import { useAuth } from "../contexts/AuthContext";
+import { useLeagueDoc } from "../hooks/useLeagueDoc";
+import type { LeagueFeature } from "../types/firestore";
+
+/** Nav items gated by league feature flags, in display order. */
+const FEATURE_PAGES: [LeagueFeature, string][] = [
+  ["submit", "Submit"],
+  ["bylaws", "Bylaws"],
+  ["leaderboards", "Leaderboards"],
+  ["survivor", "Survivor"],
+  ["hotdogs", "Hot Dogs"],
+];
 
 export default function NavBar() {
   const { theme, toggleTheme } = useTheme();
@@ -90,14 +100,18 @@ export default function NavBar() {
     handleCloseUserMenu();
   };
 
+  const { data: leagueDoc } = useLeagueDoc(leagueId ?? undefined);
+
   const getPages = () => {
     if (!leagueId) {
       return ["Select League"];
     }
-    if (leagueId !== leagueIds.mainLeague) {
-      return ["Home", "Change League"];
-    }
-    return ["Home", "Submit", "Bylaws", "Leaderboards", "Survivor", "Hot Dogs", "Change League"];
+    const features = leagueDoc?.features ?? [];
+    return [
+      "Home",
+      ...FEATURE_PAGES.filter(([feature]) => features.includes(feature)).map(([, page]) => page),
+      "Change League",
+    ];
   };
 
   const pages = getPages();

--- a/src/components/constants/LeagueConstants.ts
+++ b/src/components/constants/LeagueConstants.ts
@@ -1,6 +1,29 @@
+import type { LeagueFeature } from "../../types/firestore";
+
 export const leagueIds = {
   mainLeague: "1253779168802377728",
   walterPicks: "1223730601350135814",
 } as const;
 
 export type LeagueId = (typeof leagueIds)[keyof typeof leagueIds];
+
+/**
+ * Temporary seed/fallback for league docs that predate the `features` field
+ * (issue #94). Used when creating a league doc and when reading one that has
+ * no `features` yet. Remove once all docs carry their own flags.
+ */
+const seedFeatures: Record<string, LeagueFeature[]> = {
+  [leagueIds.mainLeague]: [
+    "survivor",
+    "leaderboards",
+    "hotdogs",
+    "bylaws",
+    "submit",
+    "custom-newsletters",
+  ],
+  [leagueIds.walterPicks]: ["custom-newsletters", "weekly-recaps"],
+};
+
+export function getSeedFeatures(leagueId: string): LeagueFeature[] {
+  return seedFeatures[leagueId] ?? [];
+}

--- a/src/hooks/useLeagueDoc.ts
+++ b/src/hooks/useLeagueDoc.ts
@@ -21,6 +21,7 @@ import {
   getPlatformLeagueId,
 } from "../utils/api/FantasyAPI";
 import type { LeagueDoc } from "../types/firestore";
+import { getSeedFeatures } from "../components/constants/LeagueConstants";
 
 interface UseLeagueDocOptions {
   /** Create the Firestore doc on first access when signed in. Default false. */
@@ -50,6 +51,7 @@ export function useLeagueDoc(
         season: parseInt(platformLeague.season, 10),
         editorUid: null,
         coEditorUids: [],
+        features: getSeedFeatures(leagueId!),
       });
       return getLeagueDoc(leagueId!);
     },

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -61,13 +61,19 @@ function Home() {
   const mainLeagueId = leagueIds.mainLeague;
   const walterPicksLeagueId = leagueIds.walterPicks;
 
-  const isMainLeague = leagueId === mainLeagueId;
-
-  const { completedWeeksDesc: recapWeekButtons } = useCompletedWeeks(leagueId, !isMainLeague);
-
   // Ensure the /leagues/{leagueId} Firestore doc exists (created on first
   // authenticated visit; anonymous visits are read-only).
-  useLeagueDoc(leagueId, { createIfMissing: true });
+  const { data: leagueDoc, isLoading: leagueDocLoading } = useLeagueDoc(leagueId, {
+    createIfMissing: true,
+  });
+  const features = leagueDoc?.features ?? [];
+  // Leagues with hand-written newsletters show their archive instead of
+  // auto-generated weekly recaps, unless "weekly-recaps" keeps both on.
+  const hasCustomNewsletters = features.includes("custom-newsletters");
+  const showRecaps =
+    !leagueDocLoading && (!hasCustomNewsletters || features.includes("weekly-recaps"));
+
+  const { completedWeeksDesc: recapWeekButtons } = useCompletedWeeks(leagueId, showRecaps);
 
   // Function to get MotW loser info for a newsletter issue
   const getMotWLoserInfo = (issueName) => {
@@ -166,13 +172,16 @@ function Home() {
     sections: ["League Overview", "League History", "League Rosters", "Recent Activity"],
   };
 
-  // Select content based on league ID from URL params
-  const content =
-    leagueId === mainLeagueId
+  // Hand-written newsletter archives are compiled into the app, so content is
+  // still keyed by league ID; the feature flag decides whether to show any.
+  const emptyContent = { mostRecentIssue: [], newsletterIssues: [] };
+  const content = !hasCustomNewsletters
+    ? emptyContent
+    : leagueId === mainLeagueId
       ? newsletterContent
       : leagueId === walterPicksLeagueId
         ? walterPicksContent
-        : { mostRecentIssue: [], newsletterIssues: [] }; // Empty newsletter content for other leagues
+        : emptyContent;
 
   const handleNavigate = (destination, isDefault = false) => {
     if (isDefault) {
@@ -208,8 +217,8 @@ function Home() {
             margin: "20px 0",
           }}
         />
-        {/* Weekly recap links for non-main leagues */}
-        {!isMainLeague && recapWeekButtons.length > 0 && (
+        {/* Weekly recap links for leagues without hand-written newsletters */}
+        {showRecaps && recapWeekButtons.length > 0 && (
           <>
             {recapWeekButtons.map((week) => (
               <GridItem key={`recap-${week}`} onClick={() => handleRecapNavigate(week)}>

--- a/src/services/firestoreCrud.ts
+++ b/src/services/firestoreCrud.ts
@@ -26,6 +26,15 @@ import {
 } from "firebase/firestore";
 import { db } from "../firebase";
 import type { UserDoc, LeagueDoc, NewsletterDoc, WeekDataDoc } from "../types/firestore";
+import { getSeedFeatures } from "../components/constants/LeagueConstants";
+
+/**
+ * Backfill `features` on league docs created before issue #94.
+ * Known special leagues fall back to their seed set; everyone else gets [].
+ */
+function withFeatures(leagueId: string, data: LeagueDoc): LeagueDoc {
+  return { ...data, features: data.features ?? getSeedFeatures(leagueId) };
+}
 
 // ---------------------------------------------------------------------------
 // Users — /users/{uid}
@@ -97,7 +106,7 @@ export async function createLeague(
  */
 export async function getLeague(leagueId: string): Promise<LeagueDoc | null> {
   const snap = await getDoc(doc(db, "leagues", leagueId));
-  return snap.exists() ? (snap.data() as LeagueDoc) : null;
+  return snap.exists() ? withFeatures(leagueId, snap.data() as LeagueDoc) : null;
 }
 
 /**
@@ -110,7 +119,7 @@ export async function getLeaguesByEditor(
 ): Promise<(LeagueDoc & { id: string })[]> {
   const q = query(collection(db, "leagues"), where("editorUid", "==", editorUid));
   const snap = await getDocs(q);
-  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as LeagueDoc) }));
+  return snap.docs.map((d) => ({ id: d.id, ...withFeatures(d.id, d.data() as LeagueDoc) }));
 }
 
 /**

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -30,6 +30,22 @@ export type Privacy = "public" | "league_only";
 export type NewsletterStatus = "draft" | "published";
 
 /**
+ * Per-league feature flags (issue #94). Leagues get the base experience by
+ * default; flags enable extra nav items and pages. Graduating a feature to
+ * all leagues = adding it to the default set at creation time.
+ */
+export type LeagueFeature =
+  | "survivor"
+  | "leaderboards"
+  | "hotdogs"
+  | "bylaws"
+  | "submit"
+  | "custom-newsletters"
+  // Auto weekly recaps are on by default; "custom-newsletters" replaces them
+  // with the hand-written archive unless "weekly-recaps" is also set.
+  | "weekly-recaps";
+
+/**
  * /users/{uid}
  *
  * Represents an authenticated user. One document per Firebase Auth UID.
@@ -72,6 +88,8 @@ export interface LeagueDoc {
   coEditorUids: string[];
   /** Privacy setting. Defaults to 'public' for Phase 1. */
   privacy: Privacy;
+  /** Extra features enabled for this league. Empty = base experience only. */
+  features: LeagueFeature[];
   /** Timestamp when the league document was created. */
   createdAt: Timestamp;
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded single-season `leagueIds.mainLeague` check with a `features: LeagueFeature[]` field on `/leagues/{leagueId}` docs (closes #94).

- `NavBar` builds its pages from the league doc's features (`submit`, `bylaws`, `leaderboards`, `survivor`, `hotdogs`) instead of `leagueId === leagueIds.mainLeague`
- `Home` shows the hand-written newsletter archive vs auto weekly recaps based on `custom-newsletters`; `weekly-recaps` keeps auto recaps on alongside an archive (WalterPicks gets both)
- New league docs are seeded from a temporary map in `LeagueConstants.ts` (main league: full set; WalterPicks: `custom-newsletters` + `weekly-recaps`; everyone else `[]`)
- Reads of pre-existing docs backfill `features` the same way — no migration needed for prod docs created before this change
- Season rollover / graduating features to all leagues now means editing Firestore docs or the default set, not code

## Test plan

- `pnpm lint` / `pnpm typecheck` / `pnpm format:check` pass; full Jest suite 131/131
- Verified in browser (emulator + prod Firestore): main league full nav + archive + no recap buttons; WalterPicks archive + recap buttons; base league slim nav + recaps; adding `features: ["survivor"]` to an arbitrary league doc surfaces Survivor in its nav; backfill path verified against the real prod league doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)