### PR TITLE
fix: clear selected league on logout + hide page nav on league picker

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
@@ -21,6 +21,7 @@ export default function NavBar() {
   const { theme, toggleTheme } = useTheme();
   const { currentUser, signOut } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
   const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null);
   const [isVisible, setIsVisible] = React.useState(true);
@@ -91,6 +92,11 @@ export default function NavBar() {
   };
 
   const getPages = () => {
+    // No page nav on the league picker itself — every button would either
+    // point back here or at the league the user is switching away from.
+    if (location.pathname === "/league-picker") {
+      return [];
+    }
     if (!leagueId) {
       return ["Select League"];
     }
@@ -130,16 +136,18 @@ export default function NavBar() {
         <Toolbar disableGutters>
           {/* Mobile menu button */}
           <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
-            <IconButton
-              size="large"
-              aria-label="menu"
-              aria-controls="menu-appbar"
-              aria-haspopup="true"
-              onClick={handleOpenNavMenu}
-              color="inherit"
-            >
-              <MenuIcon />
-            </IconButton>
+            {pages.length > 0 && (
+              <IconButton
+                size="large"
+                aria-label="menu"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleOpenNavMenu}
+                color="inherit"
+              >
+                <MenuIcon />
+              </IconButton>
+            )}
             <Menu
               id="menu-appbar"
               anchorEl={anchorElNav}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -127,6 +127,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signOut = async () => {
     try {
       await firebaseSignOut(auth);
+      // Clear the selected league so the NavBar resets to "Select League" —
+      // it survives in localStorage otherwise (bug-reports/logout-keeps-selected-league.md)
+      localStorage.removeItem("selectedLeagueId");
+      window.dispatchEvent(new Event("leagueChange"));
     } catch (error) {
       console.error("Error signing out:", error);
       throw error;


### PR DESCRIPTION
## Summary
- `AuthContext.signOut` now removes `selectedLeagueId` from localStorage and dispatches `leagueChange`, so logging out resets the NavBar to a clean state instead of keeping the previous league's nav (fixes the logout-keeps-selected-league bug report)
- The NavBar shows no page buttons on `/league-picker` — every button there either pointed back at the picker or at the league being switched away from; the mobile hamburger hides too. Theme toggle and account menu stay.

## Testing
- Verified headlessly against the emulator: sign in → pick league → logout clears the stored league and nav resets; re-login and re-pick restores the full nav
- Picker shows no page buttons even with a league selected; league home nav and the "Select League" button on other pages are unaffected
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `CI=true pnpm test` (130 passing) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)