### PR TITLE
fix: require empty coEditorUids when creating a league doc

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,9 +29,13 @@ service cloud.firestore {
       allow read: if true;
       // Docs are created unclaimed (editorUid null); creating a doc that
       // names an editor is only allowed if that editor is yourself.
+      // coEditorUids must start empty — otherwise a stranger could pre-create
+      // the doc with themselves as co-editor and retain write access after a
+      // real member claims the (seemingly unclaimed) editor role.
       allow create: if request.auth != null
         && (request.resource.data.editorUid == null
-            || request.resource.data.editorUid == request.auth.uid);
+            || request.resource.data.editorUid == request.auth.uid)
+        && request.resource.data.coEditorUids.size() == 0;
       allow update, delete: if request.auth != null
         && (resource.data.editorUid == request.auth.uid
             || request.auth.uid in resource.data.coEditorUids);


### PR DESCRIPTION
## Summary

Closes a security hole in the league-doc create rule found by live testing against the emulator: the rule only validated `editorUid`, so any signed-in user could pre-create a league's doc with `editorUid: null` **but their own uid inside `coEditorUids`**. The league still showed as "editor role unclaimed" everywhere — a real member claims it, everything looks normal — but the attacker retains full write access (league fields, newsletters, weekData) forever, since co-editors have the same powers as the editor and nothing re-checks that list.

Fix: create additionally requires `coEditorUids.size() == 0`. The client (`useLeagueDoc`) always creates with `coEditorUids: []`, so legitimate creates are unaffected.

Rules auto-deploy on merge to master, so merging this closes the hole in production. Follow-up hygiene: one-time console scan of `/leagues` for any existing doc with non-empty `coEditorUids`. The same constraint is carried forward into the `/newsletters` create rule in the upcoming remodel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)