### PR TITLE
Firestore backup, restore, and validate tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ src/newsletters/2023 Week 12
 .emulator-data
 firebase-debug.log
 firestore-debug.log
+/backups

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css}\" && eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "typecheck": "tsc --noEmit",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css}\"",
-    "emulators": "firebase emulators:start --only auth,firestore $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data"
+    "emulators": "firebase emulators:start --only auth,firestore $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data",
+    "db:backup": "node scripts/firestore-backup.js",
+    "db:restore": "node scripts/firestore-restore.js"
   },
   "eslintConfig": {
     "extends": [
@@ -73,6 +75,7 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/jest": "^30.0.0",
     "eslint": "^8.57.1",
+    "firebase-admin": "^14.1.0",
     "firebase-tools": "^15.7.0",
     "html-loader": "^4.2.0",
     "prettier": "^3.8.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "emulators": "firebase emulators:start --only auth,firestore $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data",
     "db:backup": "node scripts/firestore-backup.js",
     "db:restore": "node scripts/firestore-restore.js",
-    "db:validate": "node scripts/firestore-validate.js"
+    "db:validate": "node scripts/firestore-validate.js",
+    "db:roundtrip-test": "node scripts/firestore-roundtrip-test.js"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css}\"",
     "emulators": "firebase emulators:start --only auth,firestore $([ -d .emulator-data ] && echo '--import=.emulator-data') --export-on-exit=.emulator-data",
     "db:backup": "node scripts/firestore-backup.js",
-    "db:restore": "node scripts/firestore-restore.js"
+    "db:restore": "node scripts/firestore-restore.js",
+    "db:validate": "node scripts/firestore-validate.js"
   },
   "eslintConfig": {
     "extends": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
+      firebase-admin:
+        specifier: ^14.1.0
+        version: 14.1.0(encoding@0.1.13)
       firebase-tools:
         specifier: ^15.7.0
         version: 15.7.0(@types/node@25.2.3)(encoding@0.1.13)(typescript@5.9.3)
@@ -1080,6 +1083,9 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@firebase/analytics-compat@0.2.14':
     resolution: {integrity: sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==}
     peerDependencies:
@@ -1101,6 +1107,9 @@ packages:
   '@firebase/app-check-interop-types@0.3.2':
     resolution: {integrity: sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==}
 
+  '@firebase/app-check-interop-types@0.3.4':
+    resolution: {integrity: sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==}
+
   '@firebase/app-check-types@0.5.2':
     resolution: {integrity: sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==}
 
@@ -1115,6 +1124,9 @@ packages:
   '@firebase/app-types@0.9.2':
     resolution: {integrity: sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==}
 
+  '@firebase/app-types@0.9.5':
+    resolution: {integrity: sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==}
+
   '@firebase/app@0.10.13':
     resolution: {integrity: sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==}
 
@@ -1125,6 +1137,9 @@ packages:
 
   '@firebase/auth-interop-types@0.2.3':
     resolution: {integrity: sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==}
+
+  '@firebase/auth-interop-types@0.2.5':
+    resolution: {integrity: sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==}
 
   '@firebase/auth-types@0.12.2':
     resolution: {integrity: sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==}
@@ -1144,6 +1159,10 @@ packages:
   '@firebase/component@0.6.9':
     resolution: {integrity: sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==}
 
+  '@firebase/component@0.7.3':
+    resolution: {integrity: sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==}
+    engines: {node: '>=20.0.0'}
+
   '@firebase/data-connect@0.1.0':
     resolution: {integrity: sha512-vSe5s8dY13ilhLnfY0eYRmQsdTbH7PUFZtBbqU6JVX/j8Qp9A6G5gG6//ulbX9/1JFOF1IWNOne9c8S/DOCJaQ==}
     peerDependencies:
@@ -1152,11 +1171,22 @@ packages:
   '@firebase/database-compat@1.0.8':
     resolution: {integrity: sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==}
 
+  '@firebase/database-compat@2.1.4':
+    resolution: {integrity: sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/database-types@1.0.20':
+    resolution: {integrity: sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==}
+
   '@firebase/database-types@1.0.5':
     resolution: {integrity: sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==}
 
   '@firebase/database@1.0.8':
     resolution: {integrity: sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==}
+
+  '@firebase/database@1.1.3':
+    resolution: {integrity: sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==}
+    engines: {node: '>=20.0.0'}
 
   '@firebase/firestore-compat@0.3.38':
     resolution: {integrity: sha512-GoS0bIMMkjpLni6StSwRJarpu2+S5m346Na7gr9YZ/BZ/W3/8iHGNr9PxC+f0rNZXqS4fGRn88pICjrZEgbkqQ==}
@@ -1205,6 +1235,10 @@ packages:
 
   '@firebase/logger@0.4.2':
     resolution: {integrity: sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==}
+
+  '@firebase/logger@0.5.1':
+    resolution: {integrity: sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==}
+    engines: {node: '>=20.0.0'}
 
   '@firebase/messaging-compat@0.2.12':
     resolution: {integrity: sha512-pKsiUVZrbmRgdImYqhBNZlkKJbqjlPkVdQRZGRbkTyX4OSGKR0F/oJeCt1a8jEg5UnBp4fdVwSWSp4DuCovvEQ==}
@@ -1264,6 +1298,10 @@ packages:
   '@firebase/util@1.10.0':
     resolution: {integrity: sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==}
 
+  '@firebase/util@1.15.1':
+    resolution: {integrity: sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==}
+    engines: {node: '>=20.0.0'}
+
   '@firebase/vertexai-preview@0.0.4':
     resolution: {integrity: sha512-EBSqyu9eg8frQlVU9/HjKtHN7odqbh9MtAcVz3WwHj4gLCLOoN9F/o+oxlq3CxvFrd3CNTZwu6d2mZtVlEInng==}
     engines: {node: '>=18.0.0'}
@@ -1305,6 +1343,14 @@ packages:
     resolution: {integrity: sha512-K7pkjQCq3u6r6KTeAbEdSDCXKmL5Ve8TNPAoek6ndkFmt44kvAZh0sTwRBipkGM0B5UmWljFROqCWGP4IHXBpg==}
     engines: {node: '>=18'}
 
+  '@google-cloud/firestore@8.6.0':
+    resolution: {integrity: sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/paginator@5.0.2':
+    resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
+    engines: {node: '>=14.0.0'}
+
   '@google-cloud/paginator@6.0.0':
     resolution: {integrity: sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==}
     engines: {node: '>=18'}
@@ -1313,9 +1359,17 @@ packages:
     resolution: {integrity: sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==}
     engines: {node: '>=18'}
 
+  '@google-cloud/projectify@4.0.0':
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
+    engines: {node: '>=14.0.0'}
+
   '@google-cloud/projectify@5.0.0':
     resolution: {integrity: sha512-XXQLaIcLrOAMWvRrzz+mlUGtN6vlVNja3XQbMqRi/V7XJTAVwib3VcKd7oRwyZPkp7rBVlHGcaqdyGRrcnkhlA==}
     engines: {node: '>=18'}
+
+  '@google-cloud/promisify@4.0.0':
+    resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
+    engines: {node: '>=14'}
 
   '@google-cloud/promisify@5.0.0':
     resolution: {integrity: sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==}
@@ -1324,6 +1378,10 @@ packages:
   '@google-cloud/pubsub@5.3.0':
     resolution: {integrity: sha512-hyUoE85Rj3rRUVk3VU+Selp4MorBwEzsQEqAj6+SE+WabR9LIFitYS6A4R+PyiwVaRk/tggGD8p7bNiIY5sk4w==}
     engines: {node: '>=18'}
+
+  '@google-cloud/storage@7.21.0':
+    resolution: {integrity: sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==}
+    engines: {node: '>=14'}
 
   '@googleapis/sqladmin@35.2.0':
     resolution: {integrity: sha512-ajR9EGLs1pCkKfsXxfbVRnQ7ZPyktKNAuahHoU06CVKguWwQo3b9aFmq06PYnGk1oXc0+tlW+XEamNa/HF4pbQ==}
@@ -1816,6 +1874,9 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2139,6 +2200,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
 
@@ -2238,6 +2302,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2284,6 +2351,9 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
 
@@ -2313,6 +2383,9 @@ packages:
 
   '@types/stylis@4.2.7':
     resolution: {integrity: sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -2719,6 +2792,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
@@ -2812,6 +2888,9 @@ packages:
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -4315,6 +4394,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  farmhash-modern@1.1.0:
+    resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
+    engines: {node: '>=18.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4333,6 +4416,13 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.0:
+    resolution: {integrity: sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4416,6 +4506,10 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  firebase-admin@14.1.0:
+    resolution: {integrity: sha512-GdHh6vHWm9LVRt+3hINWczaA7fPwnN/l4xZdqzn+wNPYErrLI1x6u1mvAJM/5IGgYI9EqQgLt1EyBG8ok/hWCg==}
+    engines: {node: '>=22'}
+
   firebase-tools@15.7.0:
     resolution: {integrity: sha512-XNy/8Tk8g3RSLjUDFn2v7ULiuH/VPfs4Gh+Jo/PS7Cgatue0LwDqzRXWUYh+RajsB3ogFH/hdfekaY1PQA/LQA==}
     engines: {node: '>=20.0.0 || >=22.0.0 || >=24.0.0'}
@@ -4464,6 +4558,10 @@ packages:
         optional: true
       vue-template-compiler:
         optional: true
+
+  form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
+    engines: {node: '>= 0.12'}
 
   form-data@3.0.4:
     resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
@@ -4522,6 +4620,9 @@ packages:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -4535,6 +4636,10 @@ packages:
 
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gaxios@7.2.0:
+    resolution: {integrity: sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==}
     engines: {node: '>=18'}
 
   gcp-metadata@6.1.1:
@@ -4642,6 +4747,10 @@ packages:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
 
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
@@ -4726,6 +4835,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -5170,6 +5283,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -5649,6 +5765,10 @@ packages:
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
+  jwks-rsa@4.1.0:
+    resolution: {integrity: sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >= 23.0.0}
+
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
@@ -5710,6 +5830,9 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  limiter@1.1.5:
+    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -5742,6 +5865,9 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -5822,6 +5948,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lru-memoizer@3.0.0:
+    resolution: {integrity: sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==}
 
   lsofi@1.0.0:
     resolution: {integrity: sha512-MKr9vM1MSm+TSKfI05IYxpKV1NCxpJaBLnELyIf784zYJ5KV9lGCE1EvpA2DtXDNM3fCuFeCwXUzim/fyQRi+A==}
@@ -6022,6 +6151,11 @@ packages:
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
 
   mimic-fn@2.1.0:
@@ -6437,6 +6571,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -7419,6 +7557,10 @@ packages:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
 
+  retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
+
   retry-request@8.0.2:
     resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
@@ -7868,6 +8010,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -7986,6 +8131,10 @@ packages:
   teeny-request@10.1.0:
     resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
+
+  teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -8764,6 +8913,10 @@ packages:
 
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -10008,6 +10161,8 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@fastify/busboy@3.2.0': {}
+
   '@firebase/analytics-compat@0.2.14(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
     dependencies:
       '@firebase/analytics': 0.10.8(@firebase/app@0.10.13)
@@ -10044,6 +10199,8 @@ snapshots:
 
   '@firebase/app-check-interop-types@0.3.2': {}
 
+  '@firebase/app-check-interop-types@0.3.4': {}
+
   '@firebase/app-check-types@0.5.2': {}
 
   '@firebase/app-check@0.8.8(@firebase/app@0.10.13)':
@@ -10063,6 +10220,10 @@ snapshots:
       tslib: 2.8.1
 
   '@firebase/app-types@0.9.2': {}
+
+  '@firebase/app-types@0.9.5':
+    dependencies:
+      '@firebase/logger': 0.5.1
 
   '@firebase/app@0.10.13':
     dependencies:
@@ -10088,6 +10249,8 @@ snapshots:
 
   '@firebase/auth-interop-types@0.2.3': {}
 
+  '@firebase/auth-interop-types@0.2.5': {}
+
   '@firebase/auth-types@0.12.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)':
     dependencies:
       '@firebase/app-types': 0.9.2
@@ -10105,6 +10268,11 @@ snapshots:
   '@firebase/component@0.6.9':
     dependencies:
       '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/component@0.7.3':
+    dependencies:
+      '@firebase/util': 1.15.1
       tslib: 2.8.1
 
   '@firebase/data-connect@0.1.0(@firebase/app@0.10.13)':
@@ -10125,6 +10293,20 @@ snapshots:
       '@firebase/util': 1.10.0
       tslib: 2.8.1
 
+  '@firebase/database-compat@2.1.4':
+    dependencies:
+      '@firebase/component': 0.7.3
+      '@firebase/database': 1.1.3
+      '@firebase/database-types': 1.0.20
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.1
+      tslib: 2.8.1
+
+  '@firebase/database-types@1.0.20':
+    dependencies:
+      '@firebase/app-types': 0.9.5
+      '@firebase/util': 1.15.1
+
   '@firebase/database-types@1.0.5':
     dependencies:
       '@firebase/app-types': 0.9.2
@@ -10137,6 +10319,16 @@ snapshots:
       '@firebase/component': 0.6.9
       '@firebase/logger': 0.4.2
       '@firebase/util': 1.10.0
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/database@1.1.3':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.4
+      '@firebase/auth-interop-types': 0.2.5
+      '@firebase/component': 0.7.3
+      '@firebase/logger': 0.5.1
+      '@firebase/util': 1.15.1
       faye-websocket: 0.11.4
       tslib: 2.8.1
 
@@ -10218,6 +10410,10 @@ snapshots:
       tslib: 2.8.1
 
   '@firebase/logger@0.4.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/logger@0.5.1':
     dependencies:
       tslib: 2.8.1
 
@@ -10318,6 +10514,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@firebase/util@1.15.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@firebase/vertexai-preview@0.0.4(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)':
     dependencies:
       '@firebase/app': 0.10.13
@@ -10363,13 +10563,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@google-cloud/firestore@8.6.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      fast-deep-equal: 3.1.3
+      functional-red-black-tree: 1.0.1
+      google-gax: 5.0.6
+      protobufjs: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@google-cloud/paginator@5.0.2':
+    dependencies:
+      arrify: 2.0.1
+      extend: 3.0.2
+    optional: true
+
   '@google-cloud/paginator@6.0.0':
     dependencies:
       extend: 3.0.2
 
   '@google-cloud/precise-date@5.0.0': {}
 
+  '@google-cloud/projectify@4.0.0':
+    optional: true
+
   '@google-cloud/projectify@5.0.0': {}
+
+  '@google-cloud/promisify@4.0.0':
+    optional: true
 
   '@google-cloud/promisify@5.0.0': {}
 
@@ -10392,6 +10615,27 @@ snapshots:
       p-defer: 3.0.0
     transitivePeerDependencies:
       - supports-color
+
+  '@google-cloud/storage@7.21.0(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.10.0
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   '@googleapis/sqladmin@35.2.0':
     dependencies:
@@ -11105,6 +11349,9 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
+  '@nodable/entities@2.2.0':
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11441,6 +11688,9 @@ snapshots:
     dependencies:
       '@types/node': 25.2.3
 
+  '@types/caseless@0.12.5':
+    optional: true
+
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.1
@@ -11559,6 +11809,11 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 25.2.3
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -11600,6 +11855,14 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 25.2.3
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.6
+    optional: true
+
   '@types/resolve@1.17.1':
     dependencies:
       '@types/node': 25.2.3
@@ -11634,6 +11897,9 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/stylis@4.2.7': {}
+
+  '@types/tough-cookie@4.0.5':
+    optional: true
 
   '@types/triple-beam@1.3.5': {}
 
@@ -12030,6 +12296,9 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  anynum@1.0.1:
+    optional: true
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.5.0
@@ -12166,6 +12435,11 @@ snapshots:
   async-function@1.0.0: {}
 
   async-lock@1.4.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+    optional: true
 
   async@3.2.6: {}
 
@@ -13950,6 +14224,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  farmhash-modern@1.1.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -13967,6 +14243,22 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+    optional: true
+
+  fast-xml-parser@5.10.0:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+    optional: true
 
   fastq@1.20.1:
     dependencies:
@@ -14069,6 +14361,23 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  firebase-admin@14.1.0(encoding@0.1.13):
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@firebase/database-compat': 2.1.4
+      '@firebase/database-types': 1.0.20
+      farmhash-modern: 1.1.0
+      fast-deep-equal: 3.1.3
+      google-auth-library: 10.9.0
+      jsonwebtoken: 9.0.3
+      jwks-rsa: 4.1.0
+    optionalDependencies:
+      '@google-cloud/firestore': 8.6.0
+      '@google-cloud/storage': 7.21.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   firebase-tools@15.7.0(@types/node@25.2.3)(encoding@0.1.13)(typescript@5.9.3):
     dependencies:
@@ -14235,6 +14544,16 @@ snapshots:
     optionalDependencies:
       eslint: 8.57.1
 
+  form-data@2.5.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+    optional: true
+
   form-data@3.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -14299,6 +14618,9 @@ snapshots:
       hasown: 2.0.2
       is-callable: 1.2.7
 
+  functional-red-black-tree@1.0.1:
+    optional: true
+
   functions-have-names@1.2.3: {}
 
   fuzzy@0.1.3: {}
@@ -14320,6 +14642,14 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
       rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gaxios@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14471,6 +14801,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.2.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
       base64-js: 1.5.1
@@ -14569,6 +14910,11 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+    optional: true
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -15007,6 +15353,9 @@ snapshots:
   is-typedarray@1.0.0: {}
 
   is-unicode-supported@0.1.0: {}
+
+  is-unsafe@2.0.0:
+    optional: true
 
   is-url@1.2.4: {}
 
@@ -15982,6 +16331,17 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
+  jwks-rsa@4.1.0:
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      debug: 4.4.3
+      jose: 6.1.3
+      limiter: 1.1.5
+      lru-cache: 11.2.6
+      lru-memoizer: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   jws@4.0.1:
     dependencies:
       jwa: 2.0.1
@@ -16035,6 +16395,8 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  limiter@1.1.5: {}
+
   lines-and-columns@1.2.4: {}
 
   loader-runner@4.3.1: {}
@@ -16063,6 +16425,8 @@ snapshots:
   lodash._objecttypes@2.4.1: {}
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.clonedeep@4.5.0: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -16124,14 +16488,18 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.6:
-    optional: true
+  lru-cache@11.2.6: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  lru-memoizer@3.0.0:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      lru-cache: 11.2.6
 
   lsofi@1.0.0:
     dependencies:
@@ -16458,6 +16826,9 @@ snapshots:
   mime@1.6.0: {}
 
   mime@2.6.0: {}
+
+  mime@3.0.0:
+    optional: true
 
   mimic-fn@2.1.0: {}
 
@@ -16922,6 +17293,9 @@ snapshots:
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.2:
+    optional: true
 
   path-is-absolute@1.0.1: {}
 
@@ -18052,6 +18426,16 @@ snapshots:
 
   ret@0.1.15: {}
 
+  retry-request@7.0.2(encoding@0.1.13):
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
   retry-request@8.0.2:
     dependencies:
       extend: 3.0.2
@@ -18587,6 +18971,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+    optional: true
+
   stubs@3.0.0: {}
 
   style-loader@3.3.4(webpack@5.105.2):
@@ -18784,6 +19173,18 @@ snapshots:
       stream-events: 1.0.5
     transitivePeerDependencies:
       - supports-color
+
+  teeny-request@9.0.0(encoding@0.1.13):
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   temp-dir@2.0.0: {}
 
@@ -19851,6 +20252,9 @@ snapshots:
   xdg-basedir@4.0.0: {}
 
   xml-name-validator@3.0.0: {}
+
+  xml-naming@0.3.0:
+    optional: true
 
   xmlchars@2.2.0: {}
 

--- a/scripts/firestore-backup.js
+++ b/scripts/firestore-backup.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Export every Firestore collection (including subcollections) to timestamped
+// JSON files under backups/.
+//
+// Usage:
+//   node scripts/firestore-backup.js [--project <id>] [--out <dir>]
+//
+// Targets the emulator when FIRESTORE_EMULATOR_HOST is set, otherwise
+// production via Application Default Credentials:
+//   pnpm db:backup                                        # production
+//   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:backup # emulator
+const fs = require("fs");
+const path = require("path");
+const {
+  DEFAULT_PROJECT_ID,
+  initFirestore,
+  targetDescription,
+  serializeValue,
+} = require("./lib/firestoreBackupShared");
+
+function parseArgs(argv) {
+  const args = { project: DEFAULT_PROJECT_ID, out: "backups" };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project") args.project = argv[++i];
+    else if (argv[i] === "--out") args.out = argv[++i];
+    else {
+      console.error(`Unknown argument: ${argv[i]}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+async function dumpDocument(docSnap) {
+  const entry = { id: docSnap.id, data: serializeValue(docSnap.data()) };
+  const subcollections = await docSnap.ref.listCollections();
+  if (subcollections.length > 0) {
+    entry.collections = {};
+    for (const sub of subcollections) {
+      entry.collections[sub.id] = await dumpCollection(sub);
+    }
+  }
+  return entry;
+}
+
+async function dumpCollection(collectionRef) {
+  const snapshot = await collectionRef.get();
+  // Docs with subcollections but no fields don't appear in collection gets;
+  // listDocuments() includes them so nested data isn't silently skipped.
+  const allRefs = await collectionRef.listDocuments();
+  const seen = new Set(snapshot.docs.map((d) => d.id));
+  const docs = [];
+  for (const docSnap of snapshot.docs) docs.push(await dumpDocument(docSnap));
+  for (const ref of allRefs) {
+    if (!seen.has(ref.id)) docs.push(await dumpDocument(await ref.get()));
+  }
+  return docs;
+}
+
+function countDocs(docs) {
+  let total = docs.length;
+  for (const doc of docs) {
+    for (const sub of Object.values(doc.collections ?? {})) total += countDocs(sub);
+  }
+  return total;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { db, cleanup } = initFirestore(args.project);
+  console.log(`Backing up ${targetDescription(args.project)}`);
+
+  const stamp = new Date().toISOString().replace(/:/g, "-").replace(/\..*/, "");
+  const outDir = path.join(args.out, stamp);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const collections = await db.listCollections();
+  const manifest = {
+    createdAt: new Date().toISOString(),
+    projectId: args.project,
+    emulatorHost: process.env.FIRESTORE_EMULATOR_HOST ?? null,
+    collections: {},
+  };
+
+  for (const col of collections) {
+    const docs = await dumpCollection(col);
+    const file = path.join(outDir, `${col.id}.json`);
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ collection: col.id, documents: docs }, null, 2)
+    );
+    manifest.collections[col.id] = countDocs(docs);
+    console.log(`  ${col.id}: ${manifest.collections[col.id]} docs → ${file}`);
+  }
+
+  fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+  const total = Object.values(manifest.collections).reduce((a, b) => a + b, 0);
+  console.log(`Done. ${total} documents in ${outDir}`);
+  await cleanup();
+}
+
+main().catch((err) => {
+  console.error("Backup failed:", err);
+  process.exit(1);
+});

--- a/scripts/firestore-backup.js
+++ b/scripts/firestore-backup.js
@@ -15,9 +15,9 @@ const {
   DEFAULT_PROJECT_ID,
   initFirestore,
   targetDescription,
-  serializeValue,
   flagValue,
   countDocuments,
+  dumpCollection,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
@@ -31,32 +31,6 @@ function parseArgs(argv) {
     }
   }
   return args;
-}
-
-async function dumpDocument(docSnap) {
-  const entry = { id: docSnap.id, data: serializeValue(docSnap.data()) };
-  const subcollections = await docSnap.ref.listCollections();
-  if (subcollections.length > 0) {
-    entry.collections = {};
-    for (const sub of subcollections) {
-      entry.collections[sub.id] = await dumpCollection(sub);
-    }
-  }
-  return entry;
-}
-
-async function dumpCollection(collectionRef) {
-  const snapshot = await collectionRef.get();
-  // Docs with subcollections but no fields don't appear in collection gets;
-  // listDocuments() includes them so nested data isn't silently skipped.
-  const allRefs = await collectionRef.listDocuments();
-  const seen = new Set(snapshot.docs.map((d) => d.id));
-  const docs = [];
-  for (const docSnap of snapshot.docs) docs.push(await dumpDocument(docSnap));
-  for (const ref of allRefs) {
-    if (!seen.has(ref.id)) docs.push(await dumpDocument(await ref.get()));
-  }
-  return docs;
 }
 
 async function main() {

--- a/scripts/firestore-backup.js
+++ b/scripts/firestore-backup.js
@@ -5,6 +5,9 @@
 // Usage:
 //   node scripts/firestore-backup.js [--project <id>] [--out <dir>]
 //
+// Backups default to <repo>/backups/, which is the only place restore and
+// validate's --latest looks — treat --out as scratch, not primary storage.
+//
 // Targets the emulator when FIRESTORE_EMULATOR_HOST is set, otherwise
 // production via Application Default Credentials:
 //   pnpm db:backup                                        # production
@@ -18,10 +21,11 @@ const {
   flagValue,
   countDocuments,
   dumpCollection,
+  DEFAULT_BACKUP_ROOT,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
-  const args = { project: DEFAULT_PROJECT_ID, out: "backups" };
+  const args = { project: DEFAULT_PROJECT_ID, out: DEFAULT_BACKUP_ROOT };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--project") args.project = flagValue(argv, ++i, "--project");
     else if (argv[i] === "--out") args.out = flagValue(argv, ++i, "--out");

--- a/scripts/firestore-backup.js
+++ b/scripts/firestore-backup.js
@@ -12,6 +12,7 @@
 // production via Application Default Credentials:
 //   pnpm db:backup                                        # production
 //   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:backup # emulator
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const {
@@ -72,6 +73,17 @@ async function main() {
   fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest, null, 2));
   const total = Object.values(manifest.collections).reduce((a, b) => a + b, 0);
   console.log(`Done. ${total} documents in ${outDir}`);
+
+  // Zip alongside the directory (kept unzipped too — restore/validate read
+  // the directory). Zip failure isn't a backup failure; the files are safe.
+  try {
+    execFileSync("zip", ["-r", "-q", `${path.basename(outDir)}.zip`, path.basename(outDir)], {
+      cwd: path.dirname(outDir),
+    });
+    console.log(`Zipped to ${outDir}.zip`);
+  } catch (err) {
+    console.warn(`Warning: could not zip backup (${err.message}); the directory is intact.`);
+  }
   await cleanup();
 }
 

--- a/scripts/firestore-backup.js
+++ b/scripts/firestore-backup.js
@@ -16,13 +16,15 @@ const {
   initFirestore,
   targetDescription,
   serializeValue,
+  flagValue,
+  countDocuments,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
   const args = { project: DEFAULT_PROJECT_ID, out: "backups" };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--project") args.project = argv[++i];
-    else if (argv[i] === "--out") args.out = argv[++i];
+    if (argv[i] === "--project") args.project = flagValue(argv, ++i, "--project");
+    else if (argv[i] === "--out") args.out = flagValue(argv, ++i, "--out");
     else {
       console.error(`Unknown argument: ${argv[i]}`);
       process.exit(1);
@@ -57,14 +59,6 @@ async function dumpCollection(collectionRef) {
   return docs;
 }
 
-function countDocs(docs) {
-  let total = docs.length;
-  for (const doc of docs) {
-    for (const sub of Object.values(doc.collections ?? {})) total += countDocs(sub);
-  }
-  return total;
-}
-
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const { db, cleanup } = initFirestore(args.project);
@@ -72,6 +66,10 @@ async function main() {
 
   const stamp = new Date().toISOString().replace(/:/g, "-").replace(/\..*/, "");
   const outDir = path.join(args.out, stamp);
+  if (fs.existsSync(outDir)) {
+    console.error(`${outDir} already exists — refusing to overwrite a previous backup.`);
+    process.exit(1);
+  }
   fs.mkdirSync(outDir, { recursive: true });
 
   const collections = await db.listCollections();
@@ -89,7 +87,7 @@ async function main() {
       file,
       JSON.stringify({ collection: col.id, documents: docs }, null, 2)
     );
-    manifest.collections[col.id] = countDocs(docs);
+    manifest.collections[col.id] = countDocuments(docs);
     console.log(`  ${col.id}: ${manifest.collections[col.id]} docs → ${file}`);
   }
 

--- a/scripts/firestore-restore.js
+++ b/scripts/firestore-restore.js
@@ -11,6 +11,10 @@
 //   --production      required to touch production (no FIRESTORE_EMULATOR_HOST)
 //   --force           skip the interactive production confirmation
 //
+// Every backup file is parsed and validated against manifest.json before any
+// data is touched, so a corrupt or incomplete backup aborts with the target
+// database intact.
+//
 // Examples:
 //   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:restore --latest --wipe
 //   pnpm db:restore backups/2026-07-11T09-00-00 --production
@@ -23,6 +27,8 @@ const {
   isEmulator,
   targetDescription,
   deserializeValue,
+  flagValue,
+  countDocuments,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
@@ -35,7 +41,7 @@ function parseArgs(argv) {
     force: false,
   };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--project") args.project = argv[++i];
+    if (argv[i] === "--project") args.project = flagValue(argv, ++i, "--project");
     else if (argv[i] === "--latest") args.latest = true;
     else if (argv[i] === "--wipe") args.wipe = true;
     else if (argv[i] === "--production") args.production = true;
@@ -45,6 +51,10 @@ function parseArgs(argv) {
       console.error(`Unknown argument: ${argv[i]}`);
       process.exit(1);
     }
+  }
+  if (args.dir && args.latest) {
+    console.error("Pass either a backup directory or --latest, not both.");
+    process.exit(1);
   }
   return args;
 }
@@ -67,7 +77,69 @@ function resolveBackupDir(args) {
   return path.join(root, entries[entries.length - 1]);
 }
 
+/**
+ * Parse every collection file and cross-check it against manifest.json.
+ * Runs before any database mutation — exits on the first inconsistency so a
+ * truncated file or stray JSON can never be discovered mid-restore.
+ */
+function loadAndValidateBackup(backupDir) {
+  const manifestPath = path.join(backupDir, "manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    console.error(`${backupDir} is not a backup directory (no manifest.json)`);
+    process.exit(1);
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+  const files = fs
+    .readdirSync(backupDir)
+    .filter((f) => f.endsWith(".json") && f !== "manifest.json");
+  const fileCollections = new Set(files.map((f) => f.replace(/\.json$/, "")));
+  const manifestCollections = new Set(Object.keys(manifest.collections ?? {}));
+
+  for (const name of manifestCollections) {
+    if (!fileCollections.has(name)) {
+      console.error(`Backup is incomplete: manifest lists "${name}" but ${name}.json is missing.`);
+      process.exit(1);
+    }
+  }
+  for (const name of fileCollections) {
+    if (!manifestCollections.has(name)) {
+      console.error(`Stray file ${name}.json is not listed in manifest.json — refusing to restore it.`);
+      process.exit(1);
+    }
+  }
+
+  const collections = [];
+  for (const file of files) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(path.join(backupDir, file), "utf8"));
+    } catch (err) {
+      console.error(`Corrupt backup file ${file}: ${err.message}`);
+      process.exit(1);
+    }
+    if (typeof parsed.collection !== "string" || !Array.isArray(parsed.documents)) {
+      console.error(`Corrupt backup file ${file}: expected { collection, documents }.`);
+      process.exit(1);
+    }
+    const expected = manifest.collections[parsed.collection];
+    const actual = countDocuments(parsed.documents);
+    if (actual !== expected) {
+      console.error(
+        `Corrupt backup file ${file}: contains ${actual} docs but manifest says ${expected}.`
+      );
+      process.exit(1);
+    }
+    collections.push(parsed);
+  }
+  return collections;
+}
+
 function confirm(question) {
+  if (!process.stdin.isTTY) {
+    console.error("stdin is not a TTY — cannot confirm interactively. Use --force to skip.");
+    process.exit(1);
+  }
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
     rl.question(question, (answer) => {
@@ -83,6 +155,15 @@ async function wipeDatabase(db) {
     console.log(`  wiping ${col.id}...`);
     await db.recursiveDelete(col);
   }
+  // recursiveDelete uses BulkWriter internally, whose failures can be
+  // swallowed — verify the postcondition instead of trusting it.
+  const remaining = await db.listCollections();
+  if (remaining.length > 0) {
+    console.error(
+      `Wipe incomplete — collections still present: ${remaining.map((c) => c.id).join(", ")}`
+    );
+    process.exit(1);
+  }
 }
 
 function restoreDocs(db, writer, parentRef, docs, stats) {
@@ -91,8 +172,17 @@ function restoreDocs(db, writer, parentRef, docs, stats) {
     // Phantom parents (subcollections only, no fields) have no data key —
     // recreating them via set() would turn them into real empty docs.
     if (doc.data !== undefined) {
-      writer.set(ref, deserializeValue(doc.data, db));
-      stats.count++;
+      stats.queued++;
+      // writer.close() never rejects; failures only surface on the per-write
+      // promise, so each one must be tracked.
+      writer.set(ref, deserializeValue(doc.data, db)).then(
+        () => {
+          stats.written++;
+        },
+        (err) => {
+          stats.failures.push(`${ref.path}: ${err.message}`);
+        }
+      );
     }
     for (const [subName, subDocs] of Object.entries(doc.collections ?? {})) {
       restoreDocs(db, writer, ref.collection(subName), subDocs, stats);
@@ -103,9 +193,13 @@ function restoreDocs(db, writer, parentRef, docs, stats) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const backupDir = resolveBackupDir(args);
+  const collections = loadAndValidateBackup(backupDir);
 
-  if (!fs.existsSync(path.join(backupDir, "manifest.json"))) {
-    console.error(`${backupDir} is not a backup directory (no manifest.json)`);
+  if (isEmulator() && args.production) {
+    console.error(
+      "--production passed but FIRESTORE_EMULATOR_HOST is set — these contradict. " +
+        "Unset the env var to target production, or drop --production for the emulator."
+    );
     process.exit(1);
   }
 
@@ -137,20 +231,20 @@ async function main() {
     await wipeDatabase(db);
   }
 
-  const files = fs
-    .readdirSync(backupDir)
-    .filter((f) => f.endsWith(".json") && f !== "manifest.json");
   const writer = db.bulkWriter();
-  const stats = { count: 0 };
-  for (const file of files) {
-    const { collection, documents } = JSON.parse(
-      fs.readFileSync(path.join(backupDir, file), "utf8")
-    );
+  const stats = { queued: 0, written: 0, failures: [] };
+  for (const { collection, documents } of collections) {
     restoreDocs(db, writer, db.collection(collection), documents, stats);
     console.log(`  ${collection}: queued`);
   }
   await writer.close();
-  console.log(`Done. Restored ${stats.count} documents.`);
+
+  if (stats.failures.length > 0 || stats.written !== stats.queued) {
+    console.error(`RESTORE INCOMPLETE: ${stats.written}/${stats.queued} documents written.`);
+    for (const failure of stats.failures) console.error(`  failed: ${failure}`);
+    process.exit(1);
+  }
+  console.log(`Done. Restored ${stats.written} documents.`);
   await cleanup();
 }
 

--- a/scripts/firestore-restore.js
+++ b/scripts/firestore-restore.js
@@ -18,8 +18,6 @@
 // Examples:
 //   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:restore --latest --wipe
 //   pnpm db:restore backups/2026-07-11T09-00-00 --production
-const fs = require("fs");
-const path = require("path");
 const readline = require("readline");
 const {
   DEFAULT_PROJECT_ID,
@@ -28,7 +26,8 @@ const {
   targetDescription,
   deserializeValue,
   flagValue,
-  countDocuments,
+  resolveBackupDir,
+  loadAndValidateBackup,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
@@ -57,82 +56,6 @@ function parseArgs(argv) {
     process.exit(1);
   }
   return args;
-}
-
-function resolveBackupDir(args) {
-  if (args.dir) return args.dir;
-  if (!args.latest) {
-    console.error("Provide a backup directory or --latest. See header comment for usage.");
-    process.exit(1);
-  }
-  const root = "backups";
-  const entries = fs.existsSync(root)
-    ? fs.readdirSync(root).filter((e) => fs.existsSync(path.join(root, e, "manifest.json")))
-    : [];
-  if (entries.length === 0) {
-    console.error(`No backups found under ${root}/`);
-    process.exit(1);
-  }
-  entries.sort();
-  return path.join(root, entries[entries.length - 1]);
-}
-
-/**
- * Parse every collection file and cross-check it against manifest.json.
- * Runs before any database mutation — exits on the first inconsistency so a
- * truncated file or stray JSON can never be discovered mid-restore.
- */
-function loadAndValidateBackup(backupDir) {
-  const manifestPath = path.join(backupDir, "manifest.json");
-  if (!fs.existsSync(manifestPath)) {
-    console.error(`${backupDir} is not a backup directory (no manifest.json)`);
-    process.exit(1);
-  }
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-
-  const files = fs
-    .readdirSync(backupDir)
-    .filter((f) => f.endsWith(".json") && f !== "manifest.json");
-  const fileCollections = new Set(files.map((f) => f.replace(/\.json$/, "")));
-  const manifestCollections = new Set(Object.keys(manifest.collections ?? {}));
-
-  for (const name of manifestCollections) {
-    if (!fileCollections.has(name)) {
-      console.error(`Backup is incomplete: manifest lists "${name}" but ${name}.json is missing.`);
-      process.exit(1);
-    }
-  }
-  for (const name of fileCollections) {
-    if (!manifestCollections.has(name)) {
-      console.error(`Stray file ${name}.json is not listed in manifest.json — refusing to restore it.`);
-      process.exit(1);
-    }
-  }
-
-  const collections = [];
-  for (const file of files) {
-    let parsed;
-    try {
-      parsed = JSON.parse(fs.readFileSync(path.join(backupDir, file), "utf8"));
-    } catch (err) {
-      console.error(`Corrupt backup file ${file}: ${err.message}`);
-      process.exit(1);
-    }
-    if (typeof parsed.collection !== "string" || !Array.isArray(parsed.documents)) {
-      console.error(`Corrupt backup file ${file}: expected { collection, documents }.`);
-      process.exit(1);
-    }
-    const expected = manifest.collections[parsed.collection];
-    const actual = countDocuments(parsed.documents);
-    if (actual !== expected) {
-      console.error(
-        `Corrupt backup file ${file}: contains ${actual} docs but manifest says ${expected}.`
-      );
-      process.exit(1);
-    }
-    collections.push(parsed);
-  }
-  return collections;
 }
 
 function confirm(question) {

--- a/scripts/firestore-restore.js
+++ b/scripts/firestore-restore.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Restore Firestore from a backup directory created by firestore-backup.js.
+//
+// Usage:
+//   node scripts/firestore-restore.js <backup-dir | --latest> [options]
+//
+// Options:
+//   --latest          use the most recent directory under backups/
+//   --wipe            delete ALL existing collections before restoring
+//   --project <id>    project id (default: theoffensiveline-d8493)
+//   --production      required to touch production (no FIRESTORE_EMULATOR_HOST)
+//   --force           skip the interactive production confirmation
+//
+// Examples:
+//   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:restore --latest --wipe
+//   pnpm db:restore backups/2026-07-11T09-00-00 --production
+const fs = require("fs");
+const path = require("path");
+const readline = require("readline");
+const {
+  DEFAULT_PROJECT_ID,
+  initFirestore,
+  isEmulator,
+  targetDescription,
+  deserializeValue,
+} = require("./lib/firestoreBackupShared");
+
+function parseArgs(argv) {
+  const args = {
+    project: DEFAULT_PROJECT_ID,
+    dir: null,
+    latest: false,
+    wipe: false,
+    production: false,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project") args.project = argv[++i];
+    else if (argv[i] === "--latest") args.latest = true;
+    else if (argv[i] === "--wipe") args.wipe = true;
+    else if (argv[i] === "--production") args.production = true;
+    else if (argv[i] === "--force") args.force = true;
+    else if (!argv[i].startsWith("--") && !args.dir) args.dir = argv[i];
+    else {
+      console.error(`Unknown argument: ${argv[i]}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+function resolveBackupDir(args) {
+  if (args.dir) return args.dir;
+  if (!args.latest) {
+    console.error("Provide a backup directory or --latest. See header comment for usage.");
+    process.exit(1);
+  }
+  const root = "backups";
+  const entries = fs.existsSync(root)
+    ? fs.readdirSync(root).filter((e) => fs.existsSync(path.join(root, e, "manifest.json")))
+    : [];
+  if (entries.length === 0) {
+    console.error(`No backups found under ${root}/`);
+    process.exit(1);
+  }
+  entries.sort();
+  return path.join(root, entries[entries.length - 1]);
+}
+
+function confirm(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "yes");
+    });
+  });
+}
+
+async function wipeDatabase(db) {
+  const collections = await db.listCollections();
+  for (const col of collections) {
+    console.log(`  wiping ${col.id}...`);
+    await db.recursiveDelete(col);
+  }
+}
+
+function restoreDocs(db, writer, parentRef, docs, stats) {
+  for (const doc of docs) {
+    const ref = parentRef.doc(doc.id);
+    // Phantom parents (subcollections only, no fields) have no data key —
+    // recreating them via set() would turn them into real empty docs.
+    if (doc.data !== undefined) {
+      writer.set(ref, deserializeValue(doc.data, db));
+      stats.count++;
+    }
+    for (const [subName, subDocs] of Object.entries(doc.collections ?? {})) {
+      restoreDocs(db, writer, ref.collection(subName), subDocs, stats);
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const backupDir = resolveBackupDir(args);
+
+  if (!fs.existsSync(path.join(backupDir, "manifest.json"))) {
+    console.error(`${backupDir} is not a backup directory (no manifest.json)`);
+    process.exit(1);
+  }
+
+  if (!isEmulator()) {
+    if (!args.production) {
+      console.error(
+        "Refusing to touch production without --production. " +
+          "To use the emulator instead, set FIRESTORE_EMULATOR_HOST."
+      );
+      process.exit(1);
+    }
+    if (!args.force) {
+      const ok = await confirm(
+        `About to ${args.wipe ? "WIPE and " : ""}restore PRODUCTION (${args.project}) ` +
+          `from ${backupDir}. Type "yes" to continue: `
+      );
+      if (!ok) {
+        console.log("Aborted.");
+        process.exit(1);
+      }
+    }
+  }
+
+  const { db, cleanup } = initFirestore(args.project);
+  console.log(`Restoring ${targetDescription(args.project)} from ${backupDir}`);
+
+  if (args.wipe) {
+    console.log("Wiping existing data...");
+    await wipeDatabase(db);
+  }
+
+  const files = fs
+    .readdirSync(backupDir)
+    .filter((f) => f.endsWith(".json") && f !== "manifest.json");
+  const writer = db.bulkWriter();
+  const stats = { count: 0 };
+  for (const file of files) {
+    const { collection, documents } = JSON.parse(
+      fs.readFileSync(path.join(backupDir, file), "utf8")
+    );
+    restoreDocs(db, writer, db.collection(collection), documents, stats);
+    console.log(`  ${collection}: queued`);
+  }
+  await writer.close();
+  console.log(`Done. Restored ${stats.count} documents.`);
+  await cleanup();
+}
+
+main().catch((err) => {
+  console.error("Restore failed:", err);
+  process.exit(1);
+});

--- a/scripts/firestore-restore.js
+++ b/scripts/firestore-restore.js
@@ -5,15 +5,20 @@
 //   node scripts/firestore-restore.js <backup-dir | --latest> [options]
 //
 // Options:
-//   --latest          use the most recent directory under backups/
-//   --wipe            delete ALL existing collections before restoring
-//   --project <id>    project id (default: theoffensiveline-d8493)
-//   --production      required to touch production (no FIRESTORE_EMULATOR_HOST)
-//   --force           skip the interactive production confirmation
+//   --latest                use the most recent directory under <repo>/backups/
+//                           (backups written with --out are not discovered)
+//   --wipe                  delete ALL existing collections before restoring
+//   --project <id>          project id (default: theoffensiveline-d8493)
+//   --production            required to touch production (no FIRESTORE_EMULATOR_HOST)
+//   --force                 skip the interactive production confirmation
+//   --allow-source-mismatch permit restoring a backup into a different
+//                           project/host than it was taken from
 //
-// Every backup file is parsed and validated against manifest.json before any
-// data is touched, so a corrupt or incomplete backup aborts with the target
-// database intact.
+// Every backup file is parsed, validated against manifest.json, and
+// dry-run deserialized before any data is touched, so a corrupt or
+// incomplete backup aborts with the target database intact. The restore
+// itself is not atomic — take a fresh backup of the target before any
+// --wipe restore so an interrupted run can be rolled back.
 //
 // Examples:
 //   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:restore --latest --wipe
@@ -28,6 +33,8 @@ const {
   flagValue,
   resolveBackupDir,
   loadAndValidateBackup,
+  backupSource,
+  sourceMatchesTarget,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
@@ -38,6 +45,7 @@ function parseArgs(argv) {
     wipe: false,
     production: false,
     force: false,
+    allowSourceMismatch: false,
   };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--project") args.project = flagValue(argv, ++i, "--project");
@@ -45,6 +53,7 @@ function parseArgs(argv) {
     else if (argv[i] === "--wipe") args.wipe = true;
     else if (argv[i] === "--production") args.production = true;
     else if (argv[i] === "--force") args.force = true;
+    else if (argv[i] === "--allow-source-mismatch") args.allowSourceMismatch = true;
     else if (!argv[i].startsWith("--") && !args.dir) args.dir = argv[i];
     else {
       console.error(`Unknown argument: ${argv[i]}`);
@@ -89,6 +98,26 @@ async function wipeDatabase(db) {
   }
 }
 
+// Deserializing malformed markers (e.g. a hand-edited timestamp missing its
+// seconds) throws synchronously; prove the whole backup deserializes before
+// wiping or writing anything.
+function assertDeserializable(db, docs, prefix) {
+  for (const doc of docs) {
+    const docPath = `${prefix}/${doc.id}`;
+    if (doc.data !== undefined) {
+      try {
+        deserializeValue(doc.data, db);
+      } catch (err) {
+        console.error(`Backup contains an unrestorable value at ${docPath}: ${err.message}`);
+        process.exit(1);
+      }
+    }
+    for (const [subName, subDocs] of Object.entries(doc.collections ?? {})) {
+      assertDeserializable(db, subDocs, `${docPath}/${subName}`);
+    }
+  }
+}
+
 function restoreDocs(db, writer, parentRef, docs, stats) {
   for (const doc of docs) {
     const ref = parentRef.doc(doc.id);
@@ -116,7 +145,21 @@ function restoreDocs(db, writer, parentRef, docs, stats) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const backupDir = resolveBackupDir(args);
-  const collections = loadAndValidateBackup(backupDir);
+  const { manifest, collections } = loadAndValidateBackup(backupDir);
+
+  // Provenance guard: the backup records where it was taken from. Writing an
+  // emulator or wrong-project backup into production is almost always a
+  // mistake; restoring production backups into the emulator is routine.
+  if (!sourceMatchesTarget(manifest, args.project)) {
+    const mismatch =
+      `Backup was taken from ${backupSource(manifest)} but the target is ` +
+      `${targetDescription(args.project)}.`;
+    if (!isEmulator() && !args.allowSourceMismatch) {
+      console.error(`${mismatch} Pass --allow-source-mismatch if this is intentional.`);
+      process.exit(1);
+    }
+    console.warn(`Warning: ${mismatch}`);
+  }
 
   if (isEmulator() && args.production) {
     console.error(
@@ -149,6 +192,10 @@ async function main() {
   const { db, cleanup } = initFirestore(args.project);
   console.log(`Restoring ${targetDescription(args.project)} from ${backupDir}`);
 
+  for (const { collection, documents } of collections) {
+    assertDeserializable(db, documents, collection);
+  }
+
   if (args.wipe) {
     console.log("Wiping existing data...");
     await wipeDatabase(db);
@@ -156,9 +203,15 @@ async function main() {
 
   const writer = db.bulkWriter();
   const stats = { queued: 0, written: 0, failures: [] };
-  for (const { collection, documents } of collections) {
-    restoreDocs(db, writer, db.collection(collection), documents, stats);
-    console.log(`  ${collection}: queued`);
+  try {
+    for (const { collection, documents } of collections) {
+      restoreDocs(db, writer, db.collection(collection), documents, stats);
+      console.log(`  ${collection}: queued`);
+    }
+  } catch (err) {
+    // writer.set() can throw synchronously (Firestore-side data validation);
+    // still flush what was queued so the failure report below is accurate.
+    stats.failures.push(`enqueue aborted: ${err.message}`);
   }
   await writer.close();
 

--- a/scripts/firestore-roundtrip-test.js
+++ b/scripts/firestore-roundtrip-test.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// Integration test for the backup/restore/validate scripts: seeds every
+// Firestore value type (plus adversarial cases) into an emulator, then runs
+// backup → wipe+restore → backup → validate through the real CLIs and
+// asserts a lossless round trip. Exits 0 on pass, 1 on any failure.
+//
+// Requires a running emulator:
+//   FIRESTORE_EMULATOR_HOST=localhost:8080 node scripts/firestore-roundtrip-test.js
+//
+// Uses its own project namespace (demo-roundtrip-test), so running it
+// against your dev emulator won't touch dev data.
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { initializeApp, deleteApp } = require("firebase-admin/app");
+const {
+  getFirestore,
+  Timestamp,
+  GeoPoint,
+  FieldValue,
+} = require("firebase-admin/firestore");
+
+const PROJECT = "demo-roundtrip-test";
+const SCRIPTS = __dirname;
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error("Refusing to run: FIRESTORE_EMULATOR_HOST is not set. This test wipes data.");
+  process.exit(1);
+}
+
+let failures = 0;
+function check(label, ok, detail = "") {
+  console.log(`${ok ? "PASS" : "FAIL"}: ${label}${ok || !detail ? "" : ` — ${detail}`}`);
+  if (!ok) failures++;
+}
+
+function runCli(script, args, opts = {}) {
+  try {
+    const stdout = execFileSync("node", [path.join(SCRIPTS, script), ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    if (opts.expectFailure) {
+      return { status: err.status ?? 1, output: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+    }
+    console.error(`FAIL: ${script} ${args.join(" ")} exited ${err.status}`);
+    console.error(err.stdout ?? "", err.stderr ?? "");
+    process.exit(1);
+  }
+}
+
+async function seed(db) {
+  // Wipe the test project namespace so reruns start clean.
+  for (const col of await db.listCollections()) {
+    await db.recursiveDelete(col);
+  }
+
+  await db.doc("users/user1").set({
+    string: "hello",
+    bool: true,
+    int: 42,
+    double: 42.5,
+    nullField: null,
+    nan: NaN,
+    posInf: Infinity,
+    negInf: -Infinity,
+    timestamp: new Timestamp(1751000000, 123456000),
+    geopoint: new GeoPoint(40.7128, -74.006),
+    ref: db.doc("leagues/league1"),
+    bytes: Buffer.from("hello bytes"),
+    array: [1, "two", NaN, new Timestamp(1752000000, 0), { nested: true }],
+    map: { deep: { deeper: [new GeoPoint(1, 2)] } },
+  });
+  // Adversarial: user data shaped like our own __fs type markers.
+  await db.doc("users/hostile").set({
+    fakeTimestamp: { __fs: "timestamp", seconds: 1, nanoseconds: 2 },
+    fakeMapWrapper: { __fs: "map", value: { sneaky: true } },
+    benignFsKey: { __fs: "hello" },
+    nested: { deep: { __fs: "bytes", base64: "bm90IHJlYWw=" } },
+  });
+  await db.doc("leagues/league1").set({ name: "Test League" });
+  await db.doc("leagues/league1/newsletters/week1").set({ published: true });
+  // Phantom parent: league2 exists only via its subcollection.
+  await db.doc("leagues/league2/newsletters/week1").set({ published: false });
+  await db.doc("empty/realEmptyDoc").set({});
+}
+
+async function main() {
+  const app = initializeApp({ projectId: PROJECT });
+  const db = getFirestore(app);
+  await seed(db);
+  console.log("Seeded type zoo.");
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ff-roundtrip-"));
+  const outA = path.join(tmp, "a");
+  const outB = path.join(tmp, "b");
+
+  runCli("firestore-backup.js", ["--project", PROJECT, "--out", outA]);
+  const dirA = path.join(outA, fs.readdirSync(outA)[0]);
+  runCli("firestore-restore.js", [dirA, "--project", PROJECT, "--wipe"]);
+  runCli("firestore-backup.js", ["--project", PROJECT, "--out", outB]);
+  const dirB = path.join(outB, fs.readdirSync(outB)[0]);
+
+  for (const file of fs.readdirSync(dirA).filter((f) => f !== "manifest.json")) {
+    const a = fs.readFileSync(path.join(dirA, file), "utf8");
+    const b = fs.readFileSync(path.join(dirB, file), "utf8");
+    check(`${file} identical after wipe+restore`, a === b);
+  }
+
+  const validate = runCli("firestore-validate.js", [dirA, "--project", PROJECT]);
+  check("validate reports OK", validate.output.includes("OK: backup matches"));
+
+  // Type-level assertions on the restored data, beyond byte equality.
+  const restored = (await db.doc("users/user1").get()).data();
+  check("NaN restored as NaN", Number.isNaN(restored.nan));
+  check("Infinity restored", restored.posInf === Infinity && restored.negInf === -Infinity);
+  check("Timestamp type restored", restored.timestamp instanceof Timestamp);
+  check("Timestamp value exact", restored.timestamp.isEqual(new Timestamp(1751000000, 123456000)));
+  check("GeoPoint restored", restored.geopoint instanceof GeoPoint);
+  check("ref restored as reference", restored.ref?.path === "leagues/league1");
+  check("bytes restored", Buffer.isBuffer(restored.bytes) && restored.bytes.toString() === "hello bytes");
+  const hostile = (await db.doc("users/hostile").get()).data();
+  check(
+    "fake markers restored as plain maps",
+    !(hostile.fakeTimestamp instanceof Timestamp) && hostile.fakeTimestamp.seconds === 1
+  );
+  check("fake map wrapper unwrapped correctly", hostile.fakeMapWrapper.value.sneaky === true);
+  const phantom = await db.doc("leagues/league2").get();
+  check("phantom parent not materialized", !phantom.exists);
+  const emptyDoc = await db.doc("empty/realEmptyDoc").get();
+  check("real empty doc restored", emptyDoc.exists);
+
+  // Unsupported Firestore types must fail the backup loudly, not corrupt it.
+  let vectorSeeded = false;
+  try {
+    await db.doc("vectors/v1").set({ embedding: FieldValue.vector([1, 2, 3]) });
+    vectorSeeded = true;
+  } catch {
+    console.log("SKIP: emulator rejected vector write; unsupported-type test skipped.");
+  }
+  if (vectorSeeded) {
+    const result = runCli(
+      "firestore-backup.js",
+      ["--project", PROJECT, "--out", path.join(tmp, "c")],
+      { expectFailure: true }
+    );
+    check(
+      "backup rejects unsupported value type",
+      result.status !== 0 && result.output.includes("unsupported Firestore value type"),
+      result.output.slice(0, 200)
+    );
+    await db.doc("vectors/v1").delete();
+  }
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+  await deleteApp(app);
+  if (failures > 0) {
+    console.error(`${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("All round-trip checks passed.");
+}
+
+main().catch((err) => {
+  console.error("Round-trip test failed:", err);
+  process.exit(1);
+});

--- a/scripts/firestore-roundtrip-test.js
+++ b/scripts/firestore-roundtrip-test.js
@@ -98,11 +98,18 @@ async function main() {
   const outA = path.join(tmp, "a");
   const outB = path.join(tmp, "b");
 
+  // Each backup writes a timestamped directory plus a .zip sibling.
+  const backupDirIn = (root) =>
+    path.join(
+      root,
+      fs.readdirSync(root).find((e) => fs.statSync(path.join(root, e)).isDirectory())
+    );
+
   runCli("firestore-backup.js", ["--project", PROJECT, "--out", outA]);
-  const dirA = path.join(outA, fs.readdirSync(outA)[0]);
+  const dirA = backupDirIn(outA);
   runCli("firestore-restore.js", [dirA, "--project", PROJECT, "--wipe"]);
   runCli("firestore-backup.js", ["--project", PROJECT, "--out", outB]);
-  const dirB = path.join(outB, fs.readdirSync(outB)[0]);
+  const dirB = backupDirIn(outB);
 
   for (const file of fs.readdirSync(dirA).filter((f) => f !== "manifest.json")) {
     const a = fs.readFileSync(path.join(dirA, file), "utf8");

--- a/scripts/firestore-validate.js
+++ b/scripts/firestore-validate.js
@@ -20,6 +20,8 @@ const {
   dumpCollection,
   resolveBackupDir,
   loadAndValidateBackup,
+  backupSource,
+  sourceMatchesTarget,
 } = require("./lib/firestoreBackupShared");
 
 function parseArgs(argv) {
@@ -68,10 +70,16 @@ function flatten(docs, prefix, map) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const backupDir = resolveBackupDir(args);
-  const backupCollections = loadAndValidateBackup(backupDir);
+  const { manifest, collections: backupCollections } = loadAndValidateBackup(backupDir);
 
   const { db, cleanup } = initFirestore(args.project);
   console.log(`Validating ${backupDir} against ${targetDescription(args.project)}`);
+  if (!sourceMatchesTarget(manifest, args.project)) {
+    console.warn(
+      `Warning: this backup was taken from ${backupSource(manifest)}, ` +
+        `not from the target being validated — differences are expected.`
+    );
+  }
 
   const backupMap = new Map();
   for (const { collection, documents } of backupCollections) {
@@ -102,6 +110,9 @@ async function main() {
   console.error(
     `${onlyInBackup.length} missing from database, ${onlyInLive.length} not in backup, ` +
       `${mismatched.length} with different contents.`
+  );
+  console.error(
+    "If the app was writing during validation, re-run to rule out transient differences."
   );
   process.exit(1);
 }

--- a/scripts/firestore-validate.js
+++ b/scripts/firestore-validate.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Verify that a local backup matches the live Firestore database, document
+// by document. Read-only — safe to run against production.
+//
+// Usage:
+//   node scripts/firestore-validate.js <backup-dir | --latest> [--project <id>]
+//
+// Targets the emulator when FIRESTORE_EMULATOR_HOST is set, otherwise
+// production via Application Default Credentials. Exits 0 when the backup
+// and the database are identical, 1 with a diff report otherwise.
+//
+// Examples:
+//   pnpm db:validate --latest                              # against production
+//   FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm db:validate --latest
+const {
+  DEFAULT_PROJECT_ID,
+  initFirestore,
+  targetDescription,
+  flagValue,
+  dumpCollection,
+  resolveBackupDir,
+  loadAndValidateBackup,
+} = require("./lib/firestoreBackupShared");
+
+function parseArgs(argv) {
+  const args = { project: DEFAULT_PROJECT_ID, dir: null, latest: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project") args.project = flagValue(argv, ++i, "--project");
+    else if (argv[i] === "--latest") args.latest = true;
+    else if (!argv[i].startsWith("--") && !args.dir) args.dir = argv[i];
+    else {
+      console.error(`Unknown argument: ${argv[i]}`);
+      process.exit(1);
+    }
+  }
+  if (args.dir && args.latest) {
+    console.error("Pass either a backup directory or --latest, not both.");
+    process.exit(1);
+  }
+  return args;
+}
+
+/** JSON.stringify with sorted object keys, so field order can't cause diffs. */
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+// Flatten dumped docs into "collection/doc[/subcollection/doc...]" →
+// canonical JSON. Phantom parents (no data key) get a sentinel so a phantom
+// and an empty-but-real doc still compare as different.
+function flatten(docs, prefix, map) {
+  for (const doc of docs) {
+    const docPath = `${prefix}/${doc.id}`;
+    map.set(docPath, doc.data === undefined ? "<phantom>" : stableStringify(doc.data));
+    for (const [subName, subDocs] of Object.entries(doc.collections ?? {})) {
+      flatten(subDocs, `${docPath}/${subName}`, map);
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const backupDir = resolveBackupDir(args);
+  const backupCollections = loadAndValidateBackup(backupDir);
+
+  const { db, cleanup } = initFirestore(args.project);
+  console.log(`Validating ${backupDir} against ${targetDescription(args.project)}`);
+
+  const backupMap = new Map();
+  for (const { collection, documents } of backupCollections) {
+    flatten(documents, collection, backupMap);
+  }
+
+  const liveMap = new Map();
+  for (const col of await db.listCollections()) {
+    flatten(await dumpCollection(col), col.id, liveMap);
+  }
+
+  const onlyInBackup = [...backupMap.keys()].filter((p) => !liveMap.has(p));
+  const onlyInLive = [...liveMap.keys()].filter((p) => !backupMap.has(p));
+  const mismatched = [...backupMap.keys()].filter(
+    (p) => liveMap.has(p) && liveMap.get(p) !== backupMap.get(p)
+  );
+
+  if (onlyInBackup.length === 0 && onlyInLive.length === 0 && mismatched.length === 0) {
+    console.log(`OK: backup matches the database exactly (${liveMap.size} documents).`);
+    await cleanup();
+    return;
+  }
+
+  console.error("MISMATCH between backup and database:");
+  for (const p of onlyInBackup) console.error(`  only in backup:   ${p}`);
+  for (const p of onlyInLive) console.error(`  only in database: ${p}`);
+  for (const p of mismatched) console.error(`  differs:          ${p}`);
+  console.error(
+    `${onlyInBackup.length} missing from database, ${onlyInLive.length} not in backup, ` +
+      `${mismatched.length} with different contents.`
+  );
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("Validate failed:", err);
+  process.exit(1);
+});

--- a/scripts/lib/firestoreBackupShared.js
+++ b/scripts/lib/firestoreBackupShared.js
@@ -12,6 +12,10 @@ const {
 
 const DEFAULT_PROJECT_ID = "theoffensiveline-d8493";
 
+// Anchor the default backup location to the repo root so the scripts behave
+// the same from any working directory.
+const DEFAULT_BACKUP_ROOT = path.resolve(__dirname, "..", "..", "backups");
+
 /**
  * Initialize firebase-admin. If FIRESTORE_EMULATOR_HOST is set, the SDK
  * talks to the emulator and no credentials are needed. Otherwise it uses
@@ -64,14 +68,18 @@ async function dumpCollection(collectionRef) {
   return docs;
 }
 
-/** Resolve an explicit backup dir or the newest one under backups/. */
+/**
+ * Resolve an explicit backup dir or the newest one under the repo's backups/
+ * directory. --latest only scans the default location; backups written with
+ * a custom --out are not discovered.
+ */
 function resolveBackupDir(args) {
   if (args.dir) return args.dir;
   if (!args.latest) {
     console.error("Provide a backup directory or --latest. See header comment for usage.");
     process.exit(1);
   }
-  const root = "backups";
+  const root = DEFAULT_BACKUP_ROOT;
   const entries = fs.existsSync(root)
     ? fs.readdirSync(root).filter((e) => fs.existsSync(path.join(root, e, "manifest.json")))
     : [];
@@ -128,6 +136,15 @@ function loadAndValidateBackup(backupDir) {
       console.error(`Corrupt backup file ${file}: expected { collection, documents }.`);
       process.exit(1);
     }
+    // A file whose contents claim a different collection than its name means
+    // something was copied or renamed inside the backup dir.
+    if (parsed.collection !== file.replace(/\.json$/, "")) {
+      console.error(
+        `Corrupt backup file ${file}: contains collection "${parsed.collection}", ` +
+          `expected "${file.replace(/\.json$/, "")}".`
+      );
+      process.exit(1);
+    }
     const expected = manifest.collections[parsed.collection];
     const actual = countDocuments(parsed.documents);
     if (actual !== expected) {
@@ -138,7 +155,23 @@ function loadAndValidateBackup(backupDir) {
     }
     collections.push(parsed);
   }
-  return collections;
+  return { manifest, collections };
+}
+
+/**
+ * Describe where a backup came from, per its manifest. Used to warn or abort
+ * when a backup's origin doesn't match the current target.
+ */
+function backupSource(manifest) {
+  return manifest.emulatorHost
+    ? `EMULATOR at ${manifest.emulatorHost} (project ${manifest.projectId})`
+    : `PRODUCTION project ${manifest.projectId}`;
+}
+
+/** True when the backup's recorded origin matches the current target. */
+function sourceMatchesTarget(manifest, projectId) {
+  const currentHost = process.env.FIRESTORE_EMULATOR_HOST ?? null;
+  return manifest.emulatorHost === currentHost && manifest.projectId === projectId;
 }
 
 /** Total documents in a dumped collection, including nested subcollections. */
@@ -244,4 +277,7 @@ module.exports = {
   dumpCollection,
   resolveBackupDir,
   loadAndValidateBackup,
+  backupSource,
+  sourceMatchesTarget,
+  DEFAULT_BACKUP_ROOT,
 };

--- a/scripts/lib/firestoreBackupShared.js
+++ b/scripts/lib/firestoreBackupShared.js
@@ -26,6 +26,27 @@ function isEmulator() {
   return Boolean(process.env.FIRESTORE_EMULATOR_HOST);
 }
 
+/** Read the value following a flag, erroring if it's missing or another flag. */
+function flagValue(argv, i, name) {
+  const v = argv[i];
+  if (v === undefined || v.startsWith("--")) {
+    console.error(`Missing value for ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+/** Total documents in a dumped collection, including nested subcollections. */
+function countDocuments(docs) {
+  let total = docs.length;
+  for (const doc of docs) {
+    for (const sub of Object.values(doc.collections ?? {})) {
+      total += countDocuments(sub);
+    }
+  }
+  return total;
+}
+
 function targetDescription(projectId) {
   return isEmulator()
     ? `EMULATOR at ${process.env.FIRESTORE_EMULATOR_HOST} (project ${projectId})`
@@ -113,4 +134,6 @@ module.exports = {
   targetDescription,
   serializeValue,
   deserializeValue,
+  flagValue,
+  countDocuments,
 };

--- a/scripts/lib/firestoreBackupShared.js
+++ b/scripts/lib/firestoreBackupShared.js
@@ -37,6 +37,11 @@ function targetDescription(projectId) {
 // the round trip is lossless.
 function serializeValue(value) {
   if (value === null || value === undefined) return value;
+  // NaN/Infinity are valid Firestore numbers but JSON.stringify turns them
+  // into null — encode them explicitly so they survive the round trip.
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return { __fs: "number", value: String(value) };
+  }
   if (value instanceof Timestamp) {
     return {
       __fs: "timestamp",
@@ -57,6 +62,11 @@ function serializeValue(value) {
   if (typeof value === "object") {
     const out = {};
     for (const [k, v] of Object.entries(value)) out[k] = serializeValue(v);
+    // A user map that happens to contain a literal "__fs" key would be
+    // mistaken for a type marker on restore — wrap it to disambiguate.
+    if (Object.prototype.hasOwnProperty.call(value, "__fs")) {
+      return { __fs: "map", value: out };
+    }
     return out;
   }
   return value;
@@ -75,6 +85,17 @@ function deserializeValue(value, db) {
         return db.doc(value.path);
       case "bytes":
         return Buffer.from(value.base64, "base64");
+      case "number":
+        return Number(value.value);
+      case "map": {
+        // Escaped user map whose own keys include "__fs" — deserialize its
+        // entries directly so the wrapper isn't re-parsed as a marker.
+        const out = {};
+        for (const [k, v] of Object.entries(value.value)) {
+          out[k] = deserializeValue(v, db);
+        }
+        return out;
+      }
       default: {
         const out = {};
         for (const [k, v] of Object.entries(value)) out[k] = deserializeValue(v, db);

--- a/scripts/lib/firestoreBackupShared.js
+++ b/scripts/lib/firestoreBackupShared.js
@@ -1,5 +1,7 @@
-// Shared helpers for the Firestore backup/restore scripts (scripts/firestore-backup.js,
-// scripts/firestore-restore.js). Node-only — do not import from src/.
+// Shared helpers for the Firestore backup/restore/validate scripts in
+// scripts/. Node-only — do not import from src/.
+const fs = require("fs");
+const path = require("path");
 const { initializeApp, deleteApp } = require("firebase-admin/app");
 const {
   getFirestore,
@@ -34,6 +36,109 @@ function flagValue(argv, i, name) {
     process.exit(1);
   }
   return v;
+}
+
+async function dumpDocument(docSnap) {
+  const entry = { id: docSnap.id, data: serializeValue(docSnap.data()) };
+  const subcollections = await docSnap.ref.listCollections();
+  if (subcollections.length > 0) {
+    entry.collections = {};
+    for (const sub of subcollections) {
+      entry.collections[sub.id] = await dumpCollection(sub);
+    }
+  }
+  return entry;
+}
+
+async function dumpCollection(collectionRef) {
+  const snapshot = await collectionRef.get();
+  // Docs with subcollections but no fields don't appear in collection gets;
+  // listDocuments() includes them so nested data isn't silently skipped.
+  const allRefs = await collectionRef.listDocuments();
+  const seen = new Set(snapshot.docs.map((d) => d.id));
+  const docs = [];
+  for (const docSnap of snapshot.docs) docs.push(await dumpDocument(docSnap));
+  for (const ref of allRefs) {
+    if (!seen.has(ref.id)) docs.push(await dumpDocument(await ref.get()));
+  }
+  return docs;
+}
+
+/** Resolve an explicit backup dir or the newest one under backups/. */
+function resolveBackupDir(args) {
+  if (args.dir) return args.dir;
+  if (!args.latest) {
+    console.error("Provide a backup directory or --latest. See header comment for usage.");
+    process.exit(1);
+  }
+  const root = "backups";
+  const entries = fs.existsSync(root)
+    ? fs.readdirSync(root).filter((e) => fs.existsSync(path.join(root, e, "manifest.json")))
+    : [];
+  if (entries.length === 0) {
+    console.error(`No backups found under ${root}/`);
+    process.exit(1);
+  }
+  entries.sort();
+  return path.join(root, entries[entries.length - 1]);
+}
+
+/**
+ * Parse every collection file and cross-check it against manifest.json.
+ * Exits on the first inconsistency so a truncated file or stray JSON is
+ * caught before anything acts on the backup.
+ */
+function loadAndValidateBackup(backupDir) {
+  const manifestPath = path.join(backupDir, "manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    console.error(`${backupDir} is not a backup directory (no manifest.json)`);
+    process.exit(1);
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+  const files = fs
+    .readdirSync(backupDir)
+    .filter((f) => f.endsWith(".json") && f !== "manifest.json");
+  const fileCollections = new Set(files.map((f) => f.replace(/\.json$/, "")));
+  const manifestCollections = new Set(Object.keys(manifest.collections ?? {}));
+
+  for (const name of manifestCollections) {
+    if (!fileCollections.has(name)) {
+      console.error(`Backup is incomplete: manifest lists "${name}" but ${name}.json is missing.`);
+      process.exit(1);
+    }
+  }
+  for (const name of fileCollections) {
+    if (!manifestCollections.has(name)) {
+      console.error(`Stray file ${name}.json is not listed in manifest.json — refusing to use it.`);
+      process.exit(1);
+    }
+  }
+
+  const collections = [];
+  for (const file of files) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(path.join(backupDir, file), "utf8"));
+    } catch (err) {
+      console.error(`Corrupt backup file ${file}: ${err.message}`);
+      process.exit(1);
+    }
+    if (typeof parsed.collection !== "string" || !Array.isArray(parsed.documents)) {
+      console.error(`Corrupt backup file ${file}: expected { collection, documents }.`);
+      process.exit(1);
+    }
+    const expected = manifest.collections[parsed.collection];
+    const actual = countDocuments(parsed.documents);
+    if (actual !== expected) {
+      console.error(
+        `Corrupt backup file ${file}: contains ${actual} docs but manifest says ${expected}.`
+      );
+      process.exit(1);
+    }
+    collections.push(parsed);
+  }
+  return collections;
 }
 
 /** Total documents in a dumped collection, including nested subcollections. */
@@ -136,4 +241,7 @@ module.exports = {
   deserializeValue,
   flagValue,
   countDocuments,
+  dumpCollection,
+  resolveBackupDir,
+  loadAndValidateBackup,
 };

--- a/scripts/lib/firestoreBackupShared.js
+++ b/scripts/lib/firestoreBackupShared.js
@@ -43,7 +43,13 @@ function flagValue(argv, i, name) {
 }
 
 async function dumpDocument(docSnap) {
-  const entry = { id: docSnap.id, data: serializeValue(docSnap.data()) };
+  let data;
+  try {
+    data = serializeValue(docSnap.data());
+  } catch (err) {
+    throw new Error(`${docSnap.ref.path}: ${err.message}`);
+  }
+  const entry = { id: docSnap.id, data };
   const subcollections = await docSnap.ref.listCollections();
   if (subcollections.length > 0) {
     entry.collections = {};
@@ -201,6 +207,11 @@ function serializeValue(value) {
   if (typeof value === "number" && !Number.isFinite(value)) {
     return { __fs: "number", value: String(value) };
   }
+  // The admin SDK decodes int64 to JS numbers, so values above 2^53 have
+  // already been rounded by the time we see them — flag, can't fix.
+  if (typeof value === "number" && Number.isInteger(value) && !Number.isSafeInteger(value)) {
+    console.warn(`Warning: integer ${value} exceeds 2^53 and may have lost precision.`);
+  }
   if (value instanceof Timestamp) {
     return {
       __fs: "timestamp",
@@ -219,6 +230,15 @@ function serializeValue(value) {
   }
   if (Array.isArray(value)) return value.map(serializeValue);
   if (typeof value === "object") {
+    // Anything that isn't a plain map here is an SDK class this serializer
+    // doesn't know (e.g. VectorValue) — enumerating its internals would
+    // produce a backup that validates but restores as the wrong type.
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      throw new Error(
+        `cannot serialize unsupported Firestore value type "${value.constructor?.name}"`
+      );
+    }
     const out = {};
     for (const [k, v] of Object.entries(value)) out[k] = serializeValue(v);
     // A user map that happens to contain a literal "__fs" key would be

--- a/scripts/lib/firestoreBackupShared.js
+++ b/scripts/lib/firestoreBackupShared.js
@@ -1,0 +1,95 @@
+// Shared helpers for the Firestore backup/restore scripts (scripts/firestore-backup.js,
+// scripts/firestore-restore.js). Node-only — do not import from src/.
+const { initializeApp, deleteApp } = require("firebase-admin/app");
+const {
+  getFirestore,
+  Timestamp,
+  GeoPoint,
+  DocumentReference,
+} = require("firebase-admin/firestore");
+
+const DEFAULT_PROJECT_ID = "theoffensiveline-d8493";
+
+/**
+ * Initialize firebase-admin. If FIRESTORE_EMULATOR_HOST is set, the SDK
+ * talks to the emulator and no credentials are needed. Otherwise it uses
+ * Application Default Credentials (gcloud auth application-default login
+ * or GOOGLE_APPLICATION_CREDENTIALS).
+ */
+function initFirestore(projectId) {
+  const app = initializeApp({ projectId });
+  const db = getFirestore(app);
+  return { app, db, cleanup: () => deleteApp(app) };
+}
+
+function isEmulator() {
+  return Boolean(process.env.FIRESTORE_EMULATOR_HOST);
+}
+
+function targetDescription(projectId) {
+  return isEmulator()
+    ? `EMULATOR at ${process.env.FIRESTORE_EMULATOR_HOST} (project ${projectId})`
+    : `PRODUCTION project ${projectId}`;
+}
+
+// Firestore values that don't survive JSON round-trips are wrapped in
+// { "__fs": <type>, ... } markers. Timestamps keep seconds+nanoseconds so
+// the round trip is lossless.
+function serializeValue(value) {
+  if (value === null || value === undefined) return value;
+  if (value instanceof Timestamp) {
+    return {
+      __fs: "timestamp",
+      seconds: value.seconds,
+      nanoseconds: value.nanoseconds,
+    };
+  }
+  if (value instanceof GeoPoint) {
+    return { __fs: "geopoint", latitude: value.latitude, longitude: value.longitude };
+  }
+  if (value instanceof DocumentReference) {
+    return { __fs: "ref", path: value.path };
+  }
+  if (value instanceof Buffer || value instanceof Uint8Array) {
+    return { __fs: "bytes", base64: Buffer.from(value).toString("base64") };
+  }
+  if (Array.isArray(value)) return value.map(serializeValue);
+  if (typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) out[k] = serializeValue(v);
+    return out;
+  }
+  return value;
+}
+
+function deserializeValue(value, db) {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map((v) => deserializeValue(v, db));
+  if (typeof value === "object") {
+    switch (value.__fs) {
+      case "timestamp":
+        return new Timestamp(value.seconds, value.nanoseconds);
+      case "geopoint":
+        return new GeoPoint(value.latitude, value.longitude);
+      case "ref":
+        return db.doc(value.path);
+      case "bytes":
+        return Buffer.from(value.base64, "base64");
+      default: {
+        const out = {};
+        for (const [k, v] of Object.entries(value)) out[k] = deserializeValue(v, db);
+        return out;
+      }
+    }
+  }
+  return value;
+}
+
+module.exports = {
+  DEFAULT_PROJECT_ID,
+  initFirestore,
+  isEmulator,
+  targetDescription,
+  serializeValue,
+  deserializeValue,
+};


### PR DESCRIPTION
## Summary

Adds three maintenance CLIs for the Firestore database, run via pnpm:

- **`pnpm db:backup`** — exports every collection (including subcollections and phantom parents) to human-readable, diffable JSON under `backups/<timestamp>/`, plus a `.zip` sibling for offsite copies. Targets the emulator when `FIRESTORE_EMULATOR_HOST` is set, otherwise production via ADC.
- **`pnpm db:restore`** — restores a backup with `--wipe`/`--latest`, guarded by: pre-wipe validation of every file against the manifest (counts, filenames, dry-run deserialization), a provenance check (an emulator backup can't hit production without `--allow-source-mismatch`), a `--production` flag + interactive confirmation, and per-write failure tracking that reports incomplete restores.
- **`pnpm db:validate`** — read-only, document-by-document comparison of a backup against the live database (order-insensitive canonical JSON), used to certify a backup is faithful.

Serialization round-trips all Firestore types losslessly (Timestamp, GeoPoint, DocumentReference, Bytes, NaN/±Infinity) via `__fs` markers, with escaping for user data that mimics the markers. Unsupported types (e.g. `VectorValue`) fail the backup loudly instead of corrupting it silently.

## Testing

- **`pnpm db:roundtrip-test`** (committed integration test, requires an emulator): seeds a full type zoo + adversarial cases, runs backup → wipe+restore → backup → validate through the real CLIs — 16 assertions, all passing.
- Two multi-agent review rounds (12 reviewers total); all high/medium findings fixed and re-verified against an isolated emulator.
- Exercised against real production: backup + validate confirmed 491/491 documents match exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)