### PR TITLE
feat: newsletter entity — schema, rules, CRUD, creation flow (closes #106)

### DIFF
--- a/aigen/public-launch-plan.md
+++ b/aigen/public-launch-plan.md
@@ -164,19 +164,26 @@ For multi-league, the auto-generated newsletter is straightforward:
   - espnLeagueIds[] (manually added ESPN league IDs, since ESPN has no account-level discovery API)
 
 /leagues/{leagueId}  ← leagueId is the platform-prefixed ID: plain numeric for Sleeper, "espn_XXXXX" for ESPN
-  - platform: 'sleeper' | 'espn'
+  - platform: 'sleeper' | 'espn' | 'yahoo'
   - platformLeagueId  ← the raw ID as used by the platform's own API
-  - name, season, editorUid, coEditorUids[], privacy, createdAt
+  - name, season, createdAt
+  - (editorUid/coEditorUids/privacy/features live here temporarily; they move
+     to the newsletter doc and are removed in #103 sub-issue C)
 
-/leagues/{leagueId}/newsletters/{weekNumber}
+/newsletters/{newsletterId}  ← the top-level publication entity (#103)
+  - name, editorUid, editorName, coEditorUids[], privacy, features[]
+  - seasons[]: { leagueId, season, verified }, activeLeagueId
+  - leagueIds[] (flattened for discovery queries), createdAt
+
+/newsletters/{newsletterId}/issues/{season}_w{week}  ← weekly editions (zero-padded week)
   - status: draft | published
   - publishedAt, sections[], editorNotes
 
-/leagues/{leagueId}/newsletters/{weekNumber}/submissions/{submissionId}
+/newsletters/{newsletterId}/issues/{issueId}/submissions/{submissionId}
   - authorUid, type (meme | text | quote), content, imageUrl, status (pending | approved | rejected), createdAt
 
 /leagues/{leagueId}/weekData/{weekNumber}
-  - matchups, standings, awards, leaderboard (auto-generated JSON)
+  - matchups, standings, awards, leaderboard (auto-generated JSON; fate decided in #84)
 ```
 
 ---
@@ -187,14 +194,14 @@ For multi-league, the auto-generated newsletter is straightforward:
 
 - User accounts with Sleeper linking (connect your Sleeper username, see your leagues)
 - ESPN league entry flow already live — users enter league ID + optional private league credentials
-- Editor role claiming per league
+- Editor role claiming per league (shipped in #53; superseded by newsletter creation = claiming, #103)
 - Auto-generated newsletters (data only, no editor features)
 - Public viewing of any Sleeper or ESPN league's stats (already works today)
 
 ### Phase 2: Editor Experience
 
 - Newsletter Builder UI
-- Editor role claiming
+- Newsletter creation = claiming (replaces editor role claiming, #103)
 - Commentary and custom sections
 - Publish workflow
 - Privacy settings (public vs league-only)
@@ -234,4 +241,4 @@ For multi-league, the auto-generated newsletter is straightforward:
 
 The core bet: **every fantasy football league wants a newsletter, but nobody wants to build one from scratch.** Auto-generate the data, let an Editor add personality, let members contribute — and you've got a product that's sticky because the content is personal to each league.
 
-The Sleeper-no-OAuth problem is solvable with lightweight verification. ESPN private leagues are handled via a Vercel proxy that adds cookie auth server-side. Start with one newsletter per league, public/private toggle, and a simple editor. Ship Phase 1, get leagues onboarded, and let real usage guide what comes next.
+The Sleeper-no-OAuth problem is solvable with lightweight verification. ESPN private leagues are handled via a Vercel proxy that adds cookie auth server-side. Newsletters are the top-level entity (multiple per league allowed — see the claiming section and #103), with a public/private toggle and a simple editor. Ship Phase 1, get leagues onboarded, and let real usage guide what comes next.

--- a/aigen/public-launch-plan.md
+++ b/aigen/public-launch-plan.md
@@ -54,13 +54,13 @@ Every league on Sleeper or ESPN can have a newsletter. Here's how they get creat
 
 1. **Auto-generated base newsletter** — When someone links a league, the system generates the stats/graphs newsletter automatically (no human input needed). This is the "data layer" — the same graphs and tables you have now, powered by the platform's API data.
 
-2. **Claiming editor role** — Any league member can claim the **Editor** role for their league's newsletter. First come, first served.
+2. **Creating a newsletter = claiming** — A league member creates a newsletter for their league and becomes its **Editor** (see #103). There is no separate claim step and no unclaimed state.
    - Editor can appoint **Co-Editors** from league members
-   - If no one claims editor, the newsletter still exists with just the auto-generated content
+   - Leagues without a newsletter keep the auto-generated experience (recaps, rosters, history)
 
-3. **One newsletter per league** — A league gets exactly one newsletter. Multiple people don't create competing newsletters for the same league. The Editor owns the content; Co-Editors can contribute.
+3. **Multiple newsletters per league — allowed by design** (decision reversed 2026-07-11, #103). Platform identity is unverifiable (Sleeper has no OAuth; linking is just typing a username), so any exclusive first-come claim would let a squatter permanently lock out the real league. Instead, duplicates are harmless: they can't block anyone, they wrap only already-public stats, and the create flow steers members to the existing newsletter first ("view this one" primary, "create another" secondary).
 
-> **Why one per league?** Multiple newsletters per league sounds flexible but creates fragmentation. Nobody wants to check three different newsletters for the same league. One newsletter, one source of truth, multiple contributors.
+> **Why the reversal?** One-per-league assumed claims could be trusted. They can't be verified, so exclusivity becomes a denial-of-service tool. Fragmentation is handled socially (discovery lists show editor + season range; leagues converge on the real one) rather than by an unenforceable lock.
 
 ### Newsletter Privacy
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,42 @@ service cloud.firestore {
     }
 
     // -----------------------------------------------------------------------
+    // /newsletters/{newsletterId}   (issue #103)
+    // The top-level publication entity. Publicly readable (privacy gating is
+    // client-side until sub-issue D). Creation is claiming: the creator must
+    // name themselves editor, with no co-editors (carries forward the
+    // pre-create hole fix from #102). leagueIds must stay in sync with
+    // seasons — full projection equality isn't expressible in rules, so we
+    // assert size equality and rely on the CRUD layer for content.
+    // -----------------------------------------------------------------------
+    match /newsletters/{newsletterId} {
+      allow read: if true;
+      allow create: if request.auth != null
+        && request.resource.data.editorUid == request.auth.uid
+        && request.resource.data.coEditorUids.size() == 0
+        && request.resource.data.leagueIds.size() == request.resource.data.seasons.size();
+      allow update: if request.auth != null
+        && (resource.data.editorUid == request.auth.uid
+            || request.auth.uid in resource.data.coEditorUids)
+        // The editor role never transfers via client writes.
+        && request.resource.data.editorUid == resource.data.editorUid
+        && request.resource.data.leagueIds.size() == request.resource.data.seasons.size();
+      allow delete: if request.auth != null
+        && resource.data.editorUid == request.auth.uid;
+
+      // ---------------------------------------------------------------------
+      // /newsletters/{newsletterId}/issues/{issueId}
+      // Weekly editions. Publicly readable; writable by editor or co-editors.
+      // ---------------------------------------------------------------------
+      match /issues/{issueId} {
+        allow read: if true;
+        allow write: if request.auth != null
+          && (get(/databases/$(database)/documents/newsletters/$(newsletterId)).data.editorUid == request.auth.uid
+              || request.auth.uid in get(/databases/$(database)/documents/newsletters/$(newsletterId)).data.coEditorUids);
+      }
+    }
+
+    // -----------------------------------------------------------------------
     // /leaderboards/{docId}
     // Publicly readable. Not writable from the client (managed via console).
     // TODO: Add write rules when admin UI is built.

--- a/firestore.rules
+++ b/firestore.rules
@@ -36,9 +36,15 @@ service cloud.firestore {
         && (request.resource.data.editorUid == null
             || request.resource.data.editorUid == request.auth.uid)
         && request.resource.data.coEditorUids.size() == 0;
-      allow update, delete: if request.auth != null
+      allow delete: if request.auth != null
         && (resource.data.editorUid == request.auth.uid
             || request.auth.uid in resource.data.coEditorUids);
+      // Co-editors can update fields but never the co-editor list itself —
+      // otherwise one co-editor could strip the others or add strangers.
+      allow update: if request.auth != null
+        && (resource.data.editorUid == request.auth.uid
+            || (request.auth.uid in resource.data.coEditorUids
+                && request.resource.data.coEditorUids == resource.data.coEditorUids));
       // One-time claim of an unclaimed editor role: only the editorUid field
       // may change, and only to the claimer's own UID. First write wins —
       // a concurrent second claim fails this rule because editorUid is no
@@ -50,7 +56,9 @@ service cloud.firestore {
 
       // ---------------------------------------------------------------------
       // /leagues/{leagueId}/newsletters/{weekNumber}
-      // Publicly readable. Writable by league editor or co-editors.
+      // DEPRECATED by #103: weekly editions now live at
+      // /newsletters/{id}/issues. No code writes here anymore; this block
+      // stays (harmless, fails safe) until sub-issue C removes the old model.
       // ---------------------------------------------------------------------
       match /newsletters/{weekNumber} {
         allow read: if true;
@@ -85,12 +93,24 @@ service cloud.firestore {
       allow create: if request.auth != null
         && request.resource.data.editorUid == request.auth.uid
         && request.resource.data.coEditorUids.size() == 0
-        && request.resource.data.leagueIds.size() == request.resource.data.seasons.size();
+        && request.resource.data.leagueIds.size() == request.resource.data.seasons.size()
+        && request.resource.data.name is string
+        && request.resource.data.privacy in ['public', 'league_only']
+        && request.resource.data.activeLeagueId is string
+        && request.resource.data.features is list;
+      // Editors can update anything except the frozen fields below.
+      // Co-editors can update content but never the co-editor list itself —
+      // otherwise one co-editor could strip the others or mass-add strangers.
       allow update: if request.auth != null
         && (resource.data.editorUid == request.auth.uid
-            || request.auth.uid in resource.data.coEditorUids)
+            || (request.auth.uid in resource.data.coEditorUids
+                && request.resource.data.coEditorUids == resource.data.coEditorUids))
         // The editor role never transfers via client writes.
         && request.resource.data.editorUid == resource.data.editorUid
+        // createdAt is an audit field — backdating could game any future
+        // "oldest newsletter" anti-squatting heuristics.
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.privacy in ['public', 'league_only']
         && request.resource.data.leagueIds.size() == request.resource.data.seasons.size();
       allow delete: if request.auth != null
         && resource.data.editorUid == request.auth.uid;
@@ -98,10 +118,13 @@ service cloud.firestore {
       // ---------------------------------------------------------------------
       // /newsletters/{newsletterId}/issues/{issueId}
       // Weekly editions. Publicly readable; writable by editor or co-editors.
+      // Doc IDs must match the zero-padded {season}_w{week} convention the
+      // client relies on for chronological sorting.
       // ---------------------------------------------------------------------
       match /issues/{issueId} {
         allow read: if true;
         allow write: if request.auth != null
+          && issueId.matches('^[0-9]{4}_w[0-9]{2}$')
           && (get(/databases/$(database)/documents/newsletters/$(newsletterId)).data.editorUid == request.auth.uid
               || request.auth.uid in get(/databases/$(database)/documents/newsletters/$(newsletterId)).data.coEditorUids);
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,8 @@ import LeaderboardsHome from "./components/leaderboard/LeaderboardsHome";
 import Leaderboard from "./components/leaderboard/Leaderboard";
 import OverallLeaderboard from "./components/leaderboard/OverallLeaderboard";
 import HotDogs from "./pages/hotDogTracker/HotDogTracker";
+import LeagueNewsletters from "./pages/LeagueNewsletters";
+import NewsletterHome from "./pages/NewsletterHome";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./contexts/AuthContext";
 import Snowfall from "react-snowfall";
@@ -122,6 +124,8 @@ const AppRoutes = () => {
       <Route path="/league/:leagueId/league-rosters" element={<LeagueRosters />} />
       <Route path="/league/:leagueId/weekly-recap/:week" element={<LeagueWeeklyRecap />} />
       <Route path="/league/:leagueId/hot-dogs" element={<HotDogs />} />
+      <Route path="/league/:leagueId/newsletters" element={<LeagueNewsletters />} />
+      <Route path="/n/:newsletterId" element={<NewsletterHome />} />
 
       {/* Protected routes - auth required */}
       <Route

--- a/src/pages/LeagueNewsletters.tsx
+++ b/src/pages/LeagueNewsletters.tsx
@@ -152,7 +152,7 @@ function LeagueNewsletters(): React.ReactElement {
   });
 
   // Platform league for name prefill + season year at create time
-  const { data: platformLeague } = useQuery({
+  const { data: platformLeague, isError: platformLeagueError } = useQuery({
     queryKey: ["league", leagueId],
     queryFn: () => getLeague(leagueId!),
     enabled: !!leagueId,
@@ -177,6 +177,7 @@ function LeagueNewsletters(): React.ReactElement {
       const id = await createNewsletter({
         name: newsletterName,
         editorUid: currentUser.uid,
+        editorName: currentUser.displayName || "Unknown editor",
         coEditorUids: [],
         privacy: "public",
         features: [],
@@ -217,7 +218,13 @@ function LeagueNewsletters(): React.ReactElement {
     if (membership?.reason === "fetch-failed") {
       return <Hint>Couldn't verify league membership right now — try again later.</Hint>;
     }
-    if (!membership?.isMember) return null; // membership check still loading
+    if (platformLeagueError) {
+      return <Hint>Couldn't load this league from its platform — try again later.</Hint>;
+    }
+    if (!membership) {
+      return <Hint>Checking league membership…</Hint>;
+    }
+    if (!membership.isMember) return null; // unreachable — all reasons handled above
 
     return (
       <>
@@ -258,7 +265,8 @@ function LeagueNewsletters(): React.ReactElement {
                 <NewsletterName>{nl.name}</NewsletterName>
                 <NewsletterMeta>
                   {seasonRange(nl)} · {nl.seasons.length}{" "}
-                  {nl.seasons.length === 1 ? "season" : "seasons"}
+                  {nl.seasons.length === 1 ? "season" : "seasons"} · ed.{" "}
+                  {nl.editorName || "unknown"}
                 </NewsletterMeta>
               </NewsletterInfo>
               <PrimaryButton onClick={() => navigate(`/n/${nl.id}`)}>View</PrimaryButton>

--- a/src/pages/LeagueNewsletters.tsx
+++ b/src/pages/LeagueNewsletters.tsx
@@ -1,0 +1,275 @@
+/**
+ * LeagueNewsletters — discovery + creation view for a league (#103 sub-issue A).
+ *
+ * Lists every newsletter that includes this league (View = primary CTA) and
+ * offers "Create newsletter" as the secondary action. Creation requires a
+ * soft membership check via verifyLeagueMembership — failure blocks with
+ * guidance rather than allowing unverified creates (#106).
+ */
+import React, { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import styled from "styled-components";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../contexts/AuthContext";
+import { verifyLeagueMembership } from "../utils/leagueClaim";
+import { createNewsletter, getNewslettersForLeague } from "../services/firestoreCrud";
+import { getLeague, getPlatform } from "../utils/api/FantasyAPI";
+import type { NewsletterDoc } from "../types/firestore";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+`;
+
+const Title = styled.h1`
+  font-size: 24px;
+  margin-bottom: 4px;
+  color: ${({ theme }: any) => theme.text};
+`;
+
+const Subtitle = styled.p`
+  font-size: 14px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.7;
+  margin-bottom: 28px;
+`;
+
+const List = styled.div`
+  width: 100%;
+  max-width: 440px;
+`;
+
+const NewsletterItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background-color: ${({ theme }: any) => theme.background};
+  border: 1px solid ${({ theme }: any) => theme.neutral3}44;
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin: 8px 0;
+`;
+
+const NewsletterInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  min-width: 0;
+`;
+
+const NewsletterName = styled.span`
+  font-size: 15px;
+  font-weight: bold;
+  color: ${({ theme }: any) => theme.text};
+`;
+
+const NewsletterMeta = styled.span`
+  font-size: 12px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.6;
+`;
+
+const PrimaryButton = styled.button`
+  background-color: ${({ theme }: any) => theme.newsBlue};
+  color: ${({ theme }: any) => theme.background};
+  border: none;
+  border-radius: 20px;
+  padding: 8px 18px;
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+`;
+
+const SecondarySection = styled.div`
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid ${({ theme }: any) => theme.neutral3}33;
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;
+
+const NameInput = styled.input`
+  width: 100%;
+  max-width: 320px;
+  padding: 10px 14px;
+  border: 1px solid ${({ theme }: any) => theme.neutral3}66;
+  border-radius: 8px;
+  background-color: ${({ theme }: any) => theme.background};
+  color: ${({ theme }: any) => theme.text};
+  font-size: 14px;
+`;
+
+const Hint = styled.p`
+  font-size: 13px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.6;
+  line-height: 1.5;
+  margin: 0;
+`;
+
+const ErrorText = styled.span`
+  color: #bc293d;
+  font-size: 13px;
+`;
+
+/** Human-readable season range, e.g. "2023–2025" or "2025". */
+export function seasonRange(nl: NewsletterDoc): string {
+  const years = nl.seasons.map((s) => s.season);
+  const min = Math.min(...years);
+  const max = Math.max(...years);
+  return min === max ? String(min) : `${min}–${max}`;
+}
+
+function LeagueNewsletters(): React.ReactElement {
+  const { leagueId } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { currentUser, profile } = useAuth();
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const { data: newsletters, isLoading } = useQuery({
+    queryKey: ["newslettersForLeague", leagueId],
+    queryFn: () => getNewslettersForLeague(leagueId!),
+    enabled: !!leagueId,
+  });
+
+  // Platform league for name prefill + season year at create time
+  const { data: platformLeague } = useQuery({
+    queryKey: ["league", leagueId],
+    queryFn: () => getLeague(leagueId!),
+    enabled: !!leagueId,
+    staleTime: 24 * 60 * 60 * 1000,
+  });
+
+  const { data: membership } = useQuery({
+    queryKey: ["leagueMembership", leagueId, profile?.sleeperUserId ?? "none"],
+    queryFn: () => verifyLeagueMembership(leagueId!, profile),
+    enabled: !!leagueId && !!currentUser,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  if (!leagueId) return <Container>Missing league ID</Container>;
+
+  const handleCreate = async () => {
+    if (!currentUser || !platformLeague) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const newsletterName = name.trim() || `${platformLeague.name} Newsletter`;
+      const id = await createNewsletter({
+        name: newsletterName,
+        editorUid: currentUser.uid,
+        coEditorUids: [],
+        privacy: "public",
+        features: [],
+        seasons: [{ leagueId, season: parseInt(platformLeague.season, 10), verified: true }],
+        activeLeagueId: leagueId,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["newslettersForLeague", leagueId] });
+      navigate(`/n/${id}`);
+    } catch (e) {
+      console.error("Error creating newsletter:", e);
+      setCreateError("Couldn't create the newsletter. Please try again.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // Guidance when the soft membership check blocks creation
+  const renderCreateSection = () => {
+    if (!currentUser) {
+      return (
+        <>
+          <Hint>Sign in to create a newsletter for this league.</Hint>
+          <PrimaryButton onClick={() => navigate("/login")}>Sign in</PrimaryButton>
+        </>
+      );
+    }
+    if (membership?.reason === "no-sleeper-link" && getPlatform(leagueId) === "sleeper") {
+      return (
+        <>
+          <Hint>Link your Sleeper account to create a newsletter for this league.</Hint>
+          <PrimaryButton onClick={() => navigate("/profile")}>Go to profile</PrimaryButton>
+        </>
+      );
+    }
+    if (membership?.reason === "not-in-league") {
+      return <Hint>Only members of this league can create a newsletter for it.</Hint>;
+    }
+    if (membership?.reason === "fetch-failed") {
+      return <Hint>Couldn't verify league membership right now — try again later.</Hint>;
+    }
+    if (!membership?.isMember) return null; // membership check still loading
+
+    return (
+      <>
+        <Hint>
+          {newsletters && newsletters.length > 0
+            ? "Most leagues only need one newsletter — check the list above before creating another."
+            : "Be the first to create a newsletter for this league. You'll be its editor."}
+        </Hint>
+        <NameInput
+          type="text"
+          placeholder={platformLeague ? `${platformLeague.name} Newsletter` : "Newsletter name"}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={80}
+        />
+        <PrimaryButton onClick={handleCreate} disabled={creating || !platformLeague}>
+          {creating ? "Creating…" : "Create newsletter"}
+        </PrimaryButton>
+        {createError && <ErrorText>{createError}</ErrorText>}
+      </>
+    );
+  };
+
+  return (
+    <Container>
+      <Title>Newsletters</Title>
+      <Subtitle>{platformLeague ? platformLeague.name : "…"}</Subtitle>
+
+      {isLoading && <Hint>Loading newsletters…</Hint>}
+      {!isLoading && (!newsletters || newsletters.length === 0) && (
+        <Hint>No newsletters exist for this league yet.</Hint>
+      )}
+      {newsletters && newsletters.length > 0 && (
+        <List>
+          {newsletters.map((nl) => (
+            <NewsletterItem key={nl.id}>
+              <NewsletterInfo>
+                <NewsletterName>{nl.name}</NewsletterName>
+                <NewsletterMeta>
+                  {seasonRange(nl)} · {nl.seasons.length}{" "}
+                  {nl.seasons.length === 1 ? "season" : "seasons"}
+                </NewsletterMeta>
+              </NewsletterInfo>
+              <PrimaryButton onClick={() => navigate(`/n/${nl.id}`)}>View</PrimaryButton>
+            </NewsletterItem>
+          ))}
+        </List>
+      )}
+
+      <SecondarySection>{renderCreateSection()}</SecondarySection>
+    </Container>
+  );
+}
+
+export default LeagueNewsletters;

--- a/src/pages/LeaguePicker.tsx
+++ b/src/pages/LeaguePicker.tsx
@@ -180,6 +180,21 @@ const RemoveButton = styled.button`
   }
 `;
 
+const NewslettersButton = styled.button`
+  background: none;
+  border: 1px solid ${({ theme }: any) => theme.newsBlue}66;
+  color: ${({ theme }: any) => theme.newsBlue};
+  border-radius: 14px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:hover {
+    border-color: ${({ theme }: any) => theme.newsBlue};
+  }
+`;
+
 const EditorStatus = styled.span<{ $isYou?: boolean }>`
   font-size: 12px;
   color: ${({ theme, $isYou }: any) => ($isYou ? theme.newsBlue : theme.text)};
@@ -279,6 +294,15 @@ function LeaguePicker(): React.ReactElement {
                   </LeagueMeta>
                   <EditorStatusLine leagueId={league.id} />
                 </LeagueInfo>
+                <NewslettersButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/league/${league.id}/newsletters`);
+                  }}
+                  title="Newsletters for this league"
+                >
+                  Newsletters
+                </NewslettersButton>
                 <RemoveButton
                   onClick={(e) => handleRemoveLeague(e, league.id)}
                   title="Remove league"

--- a/src/pages/NewsletterHome.tsx
+++ b/src/pages/NewsletterHome.tsx
@@ -1,0 +1,275 @@
+/**
+ * NewsletterHome — minimal publication page at /n/:newsletterId (#103 sub-issue A).
+ *
+ * Shows the newsletter's name, editor status, and its league-seasons linking
+ * into the existing league pages. Editors get an add-season affordance:
+ * a one-click suggestion from the previous_league_id chain, plus manual
+ * league-ID entry for cross-platform history (added unverified).
+ *
+ * Just enough to make the entity testable end-to-end — the full newsletter
+ * home (features, archive, season switcher) is #103 sub-issue B.
+ */
+import React, { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import styled from "styled-components";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../contexts/AuthContext";
+import { verifyLeagueMembership } from "../utils/leagueClaim";
+import { getNewsletter, updateNewsletter } from "../services/firestoreCrud";
+import { getLeague } from "../utils/api/FantasyAPI";
+import type { NewsletterSeason } from "../types/firestore";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 20px;
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+`;
+
+const Title = styled.h1`
+  font-size: 26px;
+  margin-bottom: 4px;
+  color: ${({ theme }: any) => theme.text};
+`;
+
+const EditorBadge = styled.span`
+  font-size: 13px;
+  color: ${({ theme }: any) => theme.newsBlue};
+  margin-bottom: 24px;
+`;
+
+const SectionLabel = styled.h3`
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.5;
+  margin: 20px 0 12px;
+`;
+
+const List = styled.div`
+  width: 100%;
+  max-width: 440px;
+`;
+
+const SeasonItem = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background-color: ${({ theme }: any) => theme.background};
+  border: 1px solid ${({ theme }: any) => theme.neutral3}44;
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin: 8px 0;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+
+  &:hover {
+    border-color: ${({ theme }: any) => theme.neutral3};
+  }
+`;
+
+const SeasonYear = styled.span`
+  font-size: 15px;
+  font-weight: bold;
+  color: ${({ theme }: any) => theme.text};
+`;
+
+const SeasonMeta = styled.span`
+  font-size: 12px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.6;
+`;
+
+const ActionButton = styled.button`
+  background-color: ${({ theme }: any) => theme.newsBlue};
+  color: ${({ theme }: any) => theme.background};
+  border: none;
+  border-radius: 20px;
+  padding: 8px 18px;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+`;
+
+const ManualRow = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+`;
+
+const IdInput = styled.input`
+  padding: 8px 12px;
+  border: 1px solid ${({ theme }: any) => theme.neutral3}66;
+  border-radius: 8px;
+  background-color: ${({ theme }: any) => theme.background};
+  color: ${({ theme }: any) => theme.text};
+  font-size: 13px;
+  width: 220px;
+`;
+
+const Hint = styled.p`
+  font-size: 13px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.6;
+  line-height: 1.5;
+  margin: 4px 0;
+`;
+
+const ErrorText = styled.span`
+  color: #bc293d;
+  font-size: 13px;
+`;
+
+interface ChainSuggestion {
+  leagueId: string;
+  season: number;
+  name: string;
+}
+
+function NewsletterHome(): React.ReactElement {
+  const { newsletterId } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { currentUser, profile } = useAuth();
+  const [manualId, setManualId] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const { data: newsletter, isLoading } = useQuery({
+    queryKey: ["newsletter", newsletterId],
+    queryFn: () => getNewsletter(newsletterId!),
+    enabled: !!newsletterId,
+  });
+
+  const isEditor =
+    !!currentUser &&
+    !!newsletter &&
+    (newsletter.editorUid === currentUser.uid || newsletter.coEditorUids.includes(currentUser.uid));
+
+  // One-click prior-season suggestion: follow previous_league_id from the
+  // earliest season already in the newsletter.
+  const { data: suggestion } = useQuery<ChainSuggestion | null>({
+    queryKey: ["prevSeasonSuggestion", newsletterId, newsletter?.seasons.length],
+    enabled: isEditor && !!newsletter,
+    queryFn: async () => {
+      const earliest = [...newsletter!.seasons].sort((a, b) => a.season - b.season)[0];
+      const league = await getLeague(earliest.leagueId);
+      const prevId = league.previous_league_id;
+      if (!prevId || prevId === "0" || newsletter!.leagueIds.includes(prevId)) return null;
+      const prev = await getLeague(prevId);
+      return { leagueId: prevId, season: parseInt(prev.season, 10), name: prev.name };
+    },
+  });
+
+  const addSeason = async (season: NewsletterSeason) => {
+    if (!newsletter || !newsletterId) return;
+    setAdding(true);
+    setAddError(null);
+    try {
+      const seasons = [...newsletter.seasons, season].sort((a, b) => a.season - b.season);
+      const newest = seasons[seasons.length - 1];
+      await updateNewsletter(newsletterId, {
+        seasons,
+        activeLeagueId: newest.leagueId,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["newsletter", newsletterId] });
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : "Couldn't add that season.");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleAddSuggestion = async () => {
+    if (!suggestion) return;
+    // Chain seasons get a membership check; verified when it passes.
+    const membership = await verifyLeagueMembership(suggestion.leagueId, profile);
+    await addSeason({
+      leagueId: suggestion.leagueId,
+      season: suggestion.season,
+      verified: membership.isMember,
+    });
+  };
+
+  const handleAddManual = async () => {
+    const id = manualId.trim();
+    if (!id) return;
+    setAdding(true);
+    setAddError(null);
+    try {
+      // Fetchable check only — manual (cross-platform) seasons are unverified.
+      const league = await getLeague(id);
+      await addSeason({ leagueId: id, season: parseInt(league.season, 10), verified: false });
+      setManualId("");
+    } catch (e) {
+      setAddError("Couldn't fetch that league — check the ID (use espn_/yahoo_ prefixes).");
+      setAdding(false);
+    }
+  };
+
+  if (isLoading) return <Container>Loading…</Container>;
+  if (!newsletter) return <Container>Newsletter not found.</Container>;
+
+  const seasonsDesc = [...newsletter.seasons].sort((a, b) => b.season - a.season);
+
+  return (
+    <Container>
+      <Title>{newsletter.name}</Title>
+      {isEditor && <EditorBadge>🖋️ You're the editor</EditorBadge>}
+
+      <SectionLabel>Seasons</SectionLabel>
+      <List>
+        {seasonsDesc.map((s) => (
+          <SeasonItem key={s.leagueId} onClick={() => navigate(`/home/${s.leagueId}`)}>
+            <SeasonYear>
+              {s.season}
+              {s.leagueId === newsletter.activeLeagueId ? " · current" : ""}
+            </SeasonYear>
+            <SeasonMeta>{s.verified ? "verified" : "unverified"}</SeasonMeta>
+          </SeasonItem>
+        ))}
+      </List>
+
+      {isEditor && (
+        <>
+          <SectionLabel>Add a Season</SectionLabel>
+          {suggestion && (
+            <ActionButton onClick={handleAddSuggestion} disabled={adding}>
+              {adding ? "Adding…" : `Add ${suggestion.season} — ${suggestion.name}`}
+            </ActionButton>
+          )}
+          <ManualRow>
+            <IdInput
+              type="text"
+              placeholder="League ID (espn_… / yahoo_… / Sleeper)"
+              value={manualId}
+              onChange={(e) => setManualId(e.target.value)}
+            />
+            <ActionButton onClick={handleAddManual} disabled={adding || !manualId.trim()}>
+              Add
+            </ActionButton>
+          </ManualRow>
+          <Hint>
+            Manually added leagues are marked unverified — they show up in the newsletter but don't
+            count toward league membership.
+          </Hint>
+          {addError && <ErrorText>{addError}</ErrorText>}
+        </>
+      )}
+    </Container>
+  );
+}
+
+export default NewsletterHome;

--- a/src/pages/NewsletterHome.tsx
+++ b/src/pages/NewsletterHome.tsx
@@ -16,7 +16,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "../contexts/AuthContext";
 import { verifyLeagueMembership } from "../utils/leagueClaim";
 import { getNewsletter, updateNewsletter } from "../services/firestoreCrud";
-import { getLeague } from "../utils/api/FantasyAPI";
+import { getLeague, getPlatform } from "../utils/api/FantasyAPI";
 import type { NewsletterSeason } from "../types/firestore";
 
 const Container = styled.div`
@@ -55,7 +55,7 @@ const List = styled.div`
   max-width: 440px;
 `;
 
-const SeasonItem = styled.button`
+const SeasonItem = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -83,6 +83,16 @@ const SeasonMeta = styled.span`
   font-size: 12px;
   color: ${({ theme }: any) => theme.text};
   opacity: 0.6;
+`;
+
+const SeasonLink = styled.button`
+  background: none;
+  border: none;
+  color: ${({ theme }: any) => theme.newsBlue};
+  font-size: 12px;
+  cursor: pointer;
+  padding: 2px 6px;
+  text-decoration: underline;
 `;
 
 const ActionButton = styled.button`
@@ -159,13 +169,19 @@ function NewsletterHome(): React.ReactElement {
     (newsletter.editorUid === currentUser.uid || newsletter.coEditorUids.includes(currentUser.uid));
 
   // One-click prior-season suggestion: follow previous_league_id from the
-  // earliest season already in the newsletter.
+  // earliest Sleeper season (ESPN/Yahoo adapters have no season chain, so a
+  // cross-platform earliest season would otherwise dead-end the suggestion).
+  const seasonYears = newsletter?.seasons.map((s) => s.season).join(",");
   const { data: suggestion } = useQuery<ChainSuggestion | null>({
-    queryKey: ["prevSeasonSuggestion", newsletterId, newsletter?.seasons.length],
+    queryKey: ["prevSeasonSuggestion", newsletterId, seasonYears],
     enabled: isEditor && !!newsletter,
+    staleTime: 60 * 60 * 1000,
     queryFn: async () => {
-      const earliest = [...newsletter!.seasons].sort((a, b) => a.season - b.season)[0];
-      const league = await getLeague(earliest.leagueId);
+      const earliestSleeper = [...newsletter!.seasons]
+        .filter((s) => getPlatform(s.leagueId) === "sleeper")
+        .sort((a, b) => a.season - b.season)[0];
+      if (!earliestSleeper) return null;
+      const league = await getLeague(earliestSleeper.leagueId);
       const prevId = league.previous_league_id;
       if (!prevId || prevId === "0" || newsletter!.leagueIds.includes(prevId)) return null;
       const prev = await getLeague(prevId);
@@ -173,48 +189,80 @@ function NewsletterHome(): React.ReactElement {
     },
   });
 
-  const addSeason = async (season: NewsletterSeason) => {
-    if (!newsletter || !newsletterId) return;
+  /**
+   * Append a season. Re-fetches the doc first so a stale cache can't drop a
+   * concurrently added season. The active pointer only advances when the new
+   * season is strictly newer than the current one (season rollover) — adding
+   * history never moves it (#103: explicit pointer, never derived).
+   */
+  const addSeason = async (season: NewsletterSeason): Promise<boolean> => {
+    if (!newsletterId) return false;
+    try {
+      const fresh = await getNewsletter(newsletterId);
+      if (!fresh) throw new Error("Newsletter no longer exists.");
+      const seasons = [...fresh.seasons, season].sort((a, b) => a.season - b.season);
+      const activeYear = fresh.seasons.find((s) => s.leagueId === fresh.activeLeagueId)?.season;
+      const activeLeagueId =
+        activeYear !== undefined && season.season > activeYear
+          ? season.leagueId
+          : fresh.activeLeagueId;
+      await updateNewsletter(newsletterId, { seasons, activeLeagueId });
+      await queryClient.invalidateQueries({ queryKey: ["newsletter", newsletterId] });
+      return true;
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : "Couldn't add that season.");
+      return false;
+    }
+  };
+
+  const handleAddSuggestion = async () => {
+    if (!suggestion || adding) return;
     setAdding(true);
     setAddError(null);
     try {
-      const seasons = [...newsletter.seasons, season].sort((a, b) => a.season - b.season);
-      const newest = seasons[seasons.length - 1];
-      await updateNewsletter(newsletterId, {
-        seasons,
-        activeLeagueId: newest.leagueId,
+      // Chain seasons get a membership check; verified when it passes.
+      const membership = await verifyLeagueMembership(suggestion.leagueId, profile);
+      await addSeason({
+        leagueId: suggestion.leagueId,
+        season: suggestion.season,
+        verified: membership.isMember,
       });
-      await queryClient.invalidateQueries({ queryKey: ["newsletter", newsletterId] });
-    } catch (e) {
-      setAddError(e instanceof Error ? e.message : "Couldn't add that season.");
     } finally {
       setAdding(false);
     }
   };
 
-  const handleAddSuggestion = async () => {
-    if (!suggestion) return;
-    // Chain seasons get a membership check; verified when it passes.
-    const membership = await verifyLeagueMembership(suggestion.leagueId, profile);
-    await addSeason({
-      leagueId: suggestion.leagueId,
-      season: suggestion.season,
-      verified: membership.isMember,
-    });
-  };
-
   const handleAddManual = async () => {
     const id = manualId.trim();
-    if (!id) return;
-    setAdding(true);
+    if (!id || adding) return;
     setAddError(null);
+    // ESPN/Yahoo reuse one league ID for every season, so re-adding the same
+    // ID is usually someone trying to add the new season — explain that
+    // instead of a bare duplicate error. Per-season entries for reused IDs
+    // are a known follow-up to #103.
+    if (newsletter?.leagueIds.includes(id)) {
+      setAddError(
+        getPlatform(id) === "sleeper"
+          ? "That league is already part of this newsletter. On Sleeper, each season has its own league ID — use the new season's ID instead."
+          : `That league is already in this newsletter. ${
+              getPlatform(id) === "espn" ? "ESPN" : "Yahoo"
+            } keeps the same league ID every season, so it can't be added twice — separate entries per season aren't supported yet.`
+      );
+      return;
+    }
+    setAdding(true);
     try {
       // Fetchable check only — manual (cross-platform) seasons are unverified.
       const league = await getLeague(id);
-      await addSeason({ leagueId: id, season: parseInt(league.season, 10), verified: false });
-      setManualId("");
+      const ok = await addSeason({
+        leagueId: id,
+        season: parseInt(league.season, 10),
+        verified: false,
+      });
+      if (ok) setManualId("");
     } catch (e) {
       setAddError("Couldn't fetch that league — check the ID (use espn_/yahoo_ prefixes).");
+    } finally {
       setAdding(false);
     }
   };
@@ -232,12 +280,35 @@ function NewsletterHome(): React.ReactElement {
       <SectionLabel>Seasons</SectionLabel>
       <List>
         {seasonsDesc.map((s) => (
-          <SeasonItem key={s.leagueId} onClick={() => navigate(`/home/${s.leagueId}`)}>
+          <SeasonItem
+            key={s.season}
+            onClick={() => navigate(`/home/${s.leagueId}`)}
+            role="button"
+            style={{ cursor: "pointer" }}
+          >
             <SeasonYear>
               {s.season}
               {s.leagueId === newsletter.activeLeagueId ? " · current" : ""}
             </SeasonYear>
-            <SeasonMeta>{s.verified ? "verified" : "unverified"}</SeasonMeta>
+            <span>
+              <SeasonMeta
+                title={
+                  s.verified
+                    ? "The editor's league membership was confirmed for this season"
+                    : "Added without a membership check — display-only"
+                }
+              >
+                {s.verified ? "verified" : "unverified"}
+              </SeasonMeta>
+              <SeasonLink
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate(`/league/${s.leagueId}/league-overview`);
+                }}
+              >
+                overview
+              </SeasonLink>
+            </span>
           </SeasonItem>
         ))}
       </List>
@@ -247,7 +318,13 @@ function NewsletterHome(): React.ReactElement {
           <SectionLabel>Add a Season</SectionLabel>
           {suggestion && (
             <ActionButton onClick={handleAddSuggestion} disabled={adding}>
-              {adding ? "Adding…" : `Add ${suggestion.season} — ${suggestion.name}`}
+              {adding
+                ? "Adding…"
+                : `Add ${suggestion.season} — ${
+                    suggestion.name.length > 28
+                      ? `${suggestion.name.slice(0, 28)}…`
+                      : suggestion.name
+                  }`}
             </ActionButton>
           )}
           <ManualRow>

--- a/src/services/firestoreCrud.ts
+++ b/src/services/firestoreCrud.ts
@@ -8,12 +8,14 @@
  * Collections handled:
  *   /users/{uid}
  *   /leagues/{leagueId}
- *   /leagues/{leagueId}/newsletters/{weekNumber}
- *   /leagues/{leagueId}/weekData/{weekNumber}
+ *   /newsletters/{newsletterId}                        (issue #103)
+ *   /newsletters/{newsletterId}/issues/{season}_w{week}
+ *   /leagues/{leagueId}/weekData/{weekNumber}           (fate decided in #84)
  */
 
 import {
   doc,
+  addDoc,
   getDoc,
   setDoc,
   updateDoc,
@@ -25,7 +27,14 @@ import {
   Timestamp,
 } from "firebase/firestore";
 import { db } from "../firebase";
-import type { UserDoc, LeagueDoc, NewsletterDoc, WeekDataDoc } from "../types/firestore";
+import type {
+  UserDoc,
+  LeagueDoc,
+  NewsletterDoc,
+  NewsletterSeason,
+  IssueDoc,
+  WeekDataDoc,
+} from "../types/firestore";
 import { getSeedFeatures } from "../components/constants/LeagueConstants";
 
 /**
@@ -140,73 +149,163 @@ export async function deleteLeague(leagueId: string): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Newsletters — /leagues/{leagueId}/newsletters/{weekNumber}
+// Newsletters — /newsletters/{newsletterId}   (issue #103)
 // ---------------------------------------------------------------------------
 
 /**
- * Create or overwrite a newsletter document for a given week.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string (e.g. "1")
- * @param data - Newsletter fields
+ * Flatten seasons[].leagueId for array-contains discovery queries.
+ * The CRUD layer is the only writer of leagueIds — never set it directly.
  */
-export async function setNewsletter(
-  leagueId: string,
-  weekNumber: string,
-  data: NewsletterDoc
-): Promise<void> {
-  await setDoc(doc(db, "leagues", leagueId, "newsletters", weekNumber), data);
+function deriveLeagueIds(seasons: NewsletterSeason[]): string[] {
+  return seasons.map((s) => s.leagueId);
 }
 
 /**
- * Fetch a newsletter document for a given week.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
+ * Reject duplicate season years within one newsletter. Issue doc IDs are
+ * keyed {season}_w{week}, so two leagues covering the same year would
+ * silently overwrite each other's issues.
+ */
+function assertUniqueSeasonYears(seasons: NewsletterSeason[]): void {
+  const years = seasons.map((s) => s.season);
+  if (new Set(years).size !== years.length) {
+    throw new Error("A newsletter can only contain one league per season year.");
+  }
+}
+
+/** Newsletter fields the caller provides; leagueIds/createdAt are derived. */
+export type NewsletterCreate = Omit<NewsletterDoc, "createdAt" | "leagueIds">;
+
+/**
+ * Create a newsletter with an auto-generated ID.
+ * @param data - Newsletter fields (leagueIds is derived from seasons)
+ * @returns The new newsletter's document ID.
+ */
+export async function createNewsletter(data: NewsletterCreate): Promise<string> {
+  assertUniqueSeasonYears(data.seasons);
+  const ref = await addDoc(collection(db, "newsletters"), {
+    ...data,
+    leagueIds: deriveLeagueIds(data.seasons),
+    createdAt: Timestamp.now(),
+  });
+  return ref.id;
+}
+
+/**
+ * Fetch a newsletter by ID.
+ * @param newsletterId - Newsletter document ID
  * @returns The newsletter document or null if not found.
  */
-export async function getNewsletter(
-  leagueId: string,
-  weekNumber: string
-): Promise<NewsletterDoc | null> {
-  const snap = await getDoc(doc(db, "leagues", leagueId, "newsletters", weekNumber));
+export async function getNewsletter(newsletterId: string): Promise<NewsletterDoc | null> {
+  const snap = await getDoc(doc(db, "newsletters", newsletterId));
   return snap.exists() ? (snap.data() as NewsletterDoc) : null;
 }
 
 /**
- * Fetch all newsletters for a league.
- * @param leagueId - Parent league document ID
- * @returns Array of newsletter documents with their week numbers.
+ * Discovery query: all newsletters that include a given league-season.
+ * @param leagueId - Prefixed league document ID
+ * @returns Array of newsletter documents with their IDs.
  */
-export async function getAllNewsletters(
+export async function getNewslettersForLeague(
   leagueId: string
-): Promise<(NewsletterDoc & { weekNumber: string })[]> {
-  const snap = await getDocs(collection(db, "leagues", leagueId, "newsletters"));
-  return snap.docs.map((d) => ({
-    weekNumber: d.id,
-    ...(d.data() as NewsletterDoc),
-  }));
+): Promise<(NewsletterDoc & { id: string })[]> {
+  const q = query(collection(db, "newsletters"), where("leagueIds", "array-contains", leagueId));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as NewsletterDoc) }));
 }
 
 /**
- * Update fields on an existing newsletter document.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
+ * Fetch all newsletters where a given UID is the editor.
+ * @param editorUid - Firebase Auth UID
+ * @returns Array of newsletter documents with their IDs.
+ */
+export async function getNewslettersByEditor(
+  editorUid: string
+): Promise<(NewsletterDoc & { id: string })[]> {
+  const q = query(collection(db, "newsletters"), where("editorUid", "==", editorUid));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as NewsletterDoc) }));
+}
+
+/**
+ * Update fields on a newsletter. If seasons change, leagueIds is re-derived
+ * and duplicate season years are rejected.
+ * @param newsletterId - Newsletter document ID
  * @param data - Partial newsletter fields to merge
  */
 export async function updateNewsletter(
-  leagueId: string,
-  weekNumber: string,
-  data: Partial<NewsletterDoc>
+  newsletterId: string,
+  data: Partial<NewsletterCreate>
 ): Promise<void> {
-  await updateDoc(doc(db, "leagues", leagueId, "newsletters", weekNumber), data);
+  const payload: Partial<NewsletterDoc> = { ...data };
+  if (data.seasons) {
+    assertUniqueSeasonYears(data.seasons);
+    payload.leagueIds = deriveLeagueIds(data.seasons);
+  }
+  await updateDoc(doc(db, "newsletters", newsletterId), payload);
 }
 
 /**
  * Delete a newsletter document.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
+ * @param newsletterId - Newsletter document ID
  */
-export async function deleteNewsletter(leagueId: string, weekNumber: string): Promise<void> {
-  await deleteDoc(doc(db, "leagues", leagueId, "newsletters", weekNumber));
+export async function deleteNewsletter(newsletterId: string): Promise<void> {
+  await deleteDoc(doc(db, "newsletters", newsletterId));
+}
+
+// ---------------------------------------------------------------------------
+// Issues — /newsletters/{newsletterId}/issues/{season}_w{week}
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an issue document ID. Weeks are zero-padded so lexical order
+ * matches chronological order ("2025_w02" < "2025_w10").
+ */
+export function issueDocId(season: number, week: number): string {
+  return `${season}_w${String(week).padStart(2, "0")}`;
+}
+
+/**
+ * Create or overwrite an issue for a given season + week.
+ * @param newsletterId - Parent newsletter document ID
+ * @param season - NFL season year
+ * @param week - Week number
+ * @param data - Issue fields
+ */
+export async function setIssue(
+  newsletterId: string,
+  season: number,
+  week: number,
+  data: IssueDoc
+): Promise<void> {
+  await setDoc(doc(db, "newsletters", newsletterId, "issues", issueDocId(season, week)), data);
+}
+
+/**
+ * Fetch an issue for a given season + week.
+ * @param newsletterId - Parent newsletter document ID
+ * @param season - NFL season year
+ * @param week - Week number
+ * @returns The issue document or null if not found.
+ */
+export async function getIssue(
+  newsletterId: string,
+  season: number,
+  week: number
+): Promise<IssueDoc | null> {
+  const snap = await getDoc(
+    doc(db, "newsletters", newsletterId, "issues", issueDocId(season, week))
+  );
+  return snap.exists() ? (snap.data() as IssueDoc) : null;
+}
+
+/**
+ * Fetch all issues for a newsletter.
+ * @param newsletterId - Parent newsletter document ID
+ * @returns Array of issue documents with their IDs (e.g. "2025_w02").
+ */
+export async function getAllIssues(newsletterId: string): Promise<(IssueDoc & { id: string })[]> {
+  const snap = await getDocs(collection(db, "newsletters", newsletterId, "issues"));
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as IssueDoc) }));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/firestoreCrud.ts
+++ b/src/services/firestoreCrud.ts
@@ -161,14 +161,29 @@ function deriveLeagueIds(seasons: NewsletterSeason[]): string[] {
 }
 
 /**
- * Reject duplicate season years within one newsletter. Issue doc IDs are
- * keyed {season}_w{week}, so two leagues covering the same year would
- * silently overwrite each other's issues.
+ * Validate a newsletter's seasons and active pointer.
+ * - Non-empty: a newsletter always covers at least one season.
+ * - Unique season years: issue doc IDs are keyed {season}_w{week}, so two
+ *   leagues covering the same year would silently overwrite each other's
+ *   issues.
+ * - Unique league IDs: ESPN reuses one league ID across seasons, so the same
+ *   ID twice would break discovery and render duplicate season rows.
+ * - activeLeagueId must be one of the seasons.
  */
-function assertUniqueSeasonYears(seasons: NewsletterSeason[]): void {
+function validateSeasons(seasons: NewsletterSeason[], activeLeagueId?: string): void {
+  if (seasons.length === 0) {
+    throw new Error("A newsletter must cover at least one season.");
+  }
   const years = seasons.map((s) => s.season);
   if (new Set(years).size !== years.length) {
     throw new Error("A newsletter can only contain one league per season year.");
+  }
+  const ids = seasons.map((s) => s.leagueId);
+  if (new Set(ids).size !== ids.length) {
+    throw new Error("That league is already part of this newsletter.");
+  }
+  if (activeLeagueId !== undefined && !ids.includes(activeLeagueId)) {
+    throw new Error("activeLeagueId must reference one of the newsletter's seasons.");
   }
 }
 
@@ -181,7 +196,7 @@ export type NewsletterCreate = Omit<NewsletterDoc, "createdAt" | "leagueIds">;
  * @returns The new newsletter's document ID.
  */
 export async function createNewsletter(data: NewsletterCreate): Promise<string> {
-  assertUniqueSeasonYears(data.seasons);
+  validateSeasons(data.seasons, data.activeLeagueId);
   const ref = await addDoc(collection(db, "newsletters"), {
     ...data,
     leagueIds: deriveLeagueIds(data.seasons),
@@ -238,7 +253,7 @@ export async function updateNewsletter(
 ): Promise<void> {
   const payload: Partial<NewsletterDoc> = { ...data };
   if (data.seasons) {
-    assertUniqueSeasonYears(data.seasons);
+    validateSeasons(data.seasons, data.activeLeagueId);
     payload.leagueIds = deriveLeagueIds(data.seasons);
   }
   await updateDoc(doc(db, "newsletters", newsletterId), payload);

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -5,8 +5,9 @@
  * Collections:
  *   /users/{uid}
  *   /leagues/{leagueId}
- *   /leagues/{leagueId}/newsletters/{weekNumber}
- *   /leagues/{leagueId}/weekData/{weekNumber}
+ *   /newsletters/{newsletterId}                       (issue #103)
+ *   /newsletters/{newsletterId}/issues/{season}_w{week}
+ *   /leagues/{leagueId}/weekData/{weekNumber}          (fate decided in #84)
  *
  * leagueId format: plain numeric for Sleeper, "espn_XXXXX" for ESPN,
  * "yahoo_XXXXX" for Yahoo.
@@ -15,7 +16,7 @@
  * NOTE: ESPN credentials (espn_s2 / SWID) are NEVER stored in Firestore.
  *       They belong in localStorage only.
  *
- * NOTE: /leagues/{leagueId}/newsletters/{weekNumber}/submissions/ is Phase 3.
+ * NOTE: /newsletters/{id}/issues/{issueId}/submissions/ is Phase 3.
  */
 
 import { Timestamp } from "firebase/firestore";
@@ -23,10 +24,10 @@ import { Timestamp } from "firebase/firestore";
 /** Supported fantasy platforms. */
 export type Platform = "sleeper" | "espn" | "yahoo";
 
-/** Privacy setting for a league. Defaults to 'public' for Phase 1. */
+/** Privacy setting for a league or newsletter. Defaults to 'public'. */
 export type Privacy = "public" | "league_only";
 
-/** Newsletter publication status. */
+/** Issue publication status. */
 export type NewsletterStatus = "draft" | "published";
 
 /**
@@ -95,17 +96,68 @@ export interface LeagueDoc {
 }
 
 /**
- * /leagues/{leagueId}/newsletters/{weekNumber}
+ * One league-season entry inside a newsletter (see NewsletterDoc).
+ */
+export interface NewsletterSeason {
+  /** Prefixed league doc ID (plain numeric Sleeper, "espn_X", "yahoo_X"). */
+  leagueId: string;
+  /** NFL season year this league covers (e.g. 2025). */
+  season: number;
+  /**
+   * Whether the editor passed a membership check for this league when it was
+   * added. Unverified seasons are display-only: they never grant privacy
+   * membership (#103 decision 4).
+   */
+  verified: boolean;
+}
+
+/**
+ * /newsletters/{newsletterId}
  *
- * Represents a single week's newsletter for a league.
- * weekNumber is stored as a string document ID (e.g. "1", "2").
+ * The top-level publication entity (issue #103). An editor creates a
+ * newsletter for a league; it contains one or more league-seasons, possibly
+ * across platforms. Multiple newsletters per league are allowed by design
+ * (#103 decision 2 — exclusive claims would let squatters lock out real
+ * leagues, since platform identity is unverifiable).
  */
 export interface NewsletterDoc {
-  /** Whether this newsletter is a draft or has been published. */
+  /** Editor-chosen publication name. No uniqueness guarantee. */
+  name: string;
+  /** Firebase UID of the creator/editor. Creation is claiming — never null. */
+  editorUid: string;
+  /** Firebase UIDs of co-editors. Must be empty at creation (rules-enforced). */
+  coEditorUids: string[];
+  /** Privacy setting. Gating lands in #103 sub-issue D. */
+  privacy: Privacy;
+  /** Feature flags for this publication's extra pages. */
+  features: LeagueFeature[];
+  /** Ordered league-seasons this publication covers. */
+  seasons: NewsletterSeason[];
+  /** League ID of the current season — explicit, never derived from order. */
+  activeLeagueId: string;
+  /**
+   * Flattened seasons[].leagueId, kept in sync by the CRUD layer for
+   * array-contains discovery queries. Never write directly.
+   */
+  leagueIds: string[];
+  /** Timestamp when the newsletter was created. */
+  createdAt: Timestamp;
+}
+
+/**
+ * /newsletters/{newsletterId}/issues/{season}_w{week}
+ *
+ * A weekly edition of a newsletter. Doc IDs zero-pad the week ("2025_w02")
+ * so lexical order matches chronological order. Placeholder shape — the
+ * full builder schema lands with #84. Replaces the never-used
+ * /leagues/{id}/newsletters subcollection.
+ */
+export interface IssueDoc {
+  /** Whether this issue is a draft or has been published. */
   status: NewsletterStatus;
-  /** Timestamp when the newsletter was published. Null if still draft. */
+  /** Timestamp when the issue was published. Null if still draft. */
   publishedAt: Timestamp | null;
-  /** Ordered list of section identifiers included in this newsletter. */
+  /** Ordered list of section identifiers included in this issue. */
   sections: string[];
   /** Free-form notes from the editor. */
   editorNotes: string;

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -125,6 +125,13 @@ export interface NewsletterDoc {
   name: string;
   /** Firebase UID of the creator/editor. Creation is claiming — never null. */
   editorUid: string;
+  /**
+   * Editor's display name, denormalized at create time. Discovery lists show
+   * it so league members can tell the real newsletter from an impersonator
+   * (#103 decision 2) — user docs aren't publicly readable, so it can't be
+   * looked up.
+   */
+  editorName: string;
   /** Firebase UIDs of co-editors. Must be empty at creation (rules-enforced). */
   coEditorUids: string[];
   /** Privacy setting. Gating lands in #103 sub-issue D. */


### PR DESCRIPTION
## Summary

First implementation slice of the #103 remodel (sub-issue A, closes #106). Introduces `/newsletters` as the top-level publication entity **alongside** the existing league-doc model — Home, NavBar, and the claim flow are untouched until sub-issues B/C.

- `NewsletterDoc`/`NewsletterSeason`/`IssueDoc` types; the never-used league-scoped weekly newsletter CRUD is replaced by the `issues` subcollection model (zero-padded IDs, `2025_w02`)
- CRUD derives `leagueIds` from `seasons` in one place; rejects duplicate season years, duplicate league IDs (ESPN reuses one ID across seasons), empty seasons, and dangling `activeLeagueId`
- Rules: authenticated create with creator-as-editor + empty `coEditorUids` (#102 carried forward) + field-type checks; co-editors can update content but never the co-editor list (applied to `/leagues` too); `createdAt` frozen; issue IDs regex-enforced
- Discovery + create page at `/league/:leagueId/newsletters` — existing newsletters first (name · season range · **ed. {editorName}**, denormalized at create since user docs aren't publicly readable), soft membership gate blocks with guidance
- Minimal newsletter home at `/n/:newsletterId`: seasons list (links to league home + overview), editor add-season flow — `previous_league_id` chain suggestion (verified), manual cross-platform IDs (unverified), platform-aware duplicate errors; `activeLeagueId` only advances on strictly-newer seasons
- "Newsletters" entry point on league picker rows
- `public-launch-plan.md` fully updated for the #103 multiplicity reversal (claiming section, schema block, phases, summary)

## Review

Six-agent review (1 Fable, 2 Opus, 3 Sonnet) across rules security, React correctness, CRUD fallout, UX, and spec conformance; all should-fix findings addressed in the second commit, with load-bearing claims verified against the code (ESPN season derivation, adapter `previous_league_id`, `/users` read rules).

## Test plan

- `pnpm lint` / `pnpm typecheck` / `pnpm format:check` pass; Jest suite 130/130
- Emulator walkthrough verified by Matthew: create as linked member, chain-add prior season (pointer stays put), duplicate/bogus ID errors, non-member + unlinked users blocked with guidance, discovery list with editor attribution, existing picker/home/recap flows unaffected

Note for post-merge: rules auto-deploy; the `/leagues` update-rule tightening (co-editor list editable by editor only) is invisible to current app behavior — claim flow untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)