### PR TITLE
feat: parallel-run — feature toggles, legacy labeling, retire claim machinery (closes #110)

### DIFF
--- a/aigen/public-launch-plan.md
+++ b/aigen/public-launch-plan.md
@@ -170,9 +170,9 @@ For multi-league, the auto-generated newsletter is straightforward:
 /leagues/{leagueId}  ← leagueId is the platform-prefixed ID: plain numeric for Sleeper, "espn_XXXXX" for ESPN
   - platform: 'sleeper' | 'espn' | 'yahoo'
   - platformLeagueId  ← the raw ID as used by the platform's own API
-  - name, season, createdAt
-  - (editorUid/coEditorUids/privacy/features live here temporarily; they move
-     to the newsletter doc and are removed in #103 sub-issue C)
+  - name, season, features, createdAt
+  - (demoted by #110: editor/privacy moved to the newsletter doc; `features`
+     stays for the legacy experience until ladder step 5)
 
 /newsletters/{newsletterId}  ← the top-level publication entity (#103)
   - name, editorUid, editorName, coEditorUids[], privacy, features[]

--- a/aigen/public-launch-plan.md
+++ b/aigen/public-launch-plan.md
@@ -62,6 +62,10 @@ Every league on Sleeper or ESPN can have a newsletter. Here's how they get creat
 
 > **Why the reversal?** One-per-league assumed claims could be trusted. They can't be verified, so exclusivity becomes a denial-of-service tool. Fragmentation is handled socially (discovery lists show editor + season range; leagues converge on the real one) rather than by an unenforceable lock.
 
+### Migration strategy: freeze-and-parallel (#110)
+
+The Offensive Line runs in both systems during the transition: the hardcoded legacy experience is frozen as a labeled archive, and a new dynamic newsletter (full feature flags) carries forward. Ladder: (1) seed + freeze + retire claim machinery → (2) #84 builder authors new issues; legacy stops growing → (3) legacyRoute pointer docs surface the hand-written archive in the newsletter's issue list → (4) feature pages re-key to newsletters → (5) delete the legacy scaffolding (compiled newsletter components stay forever — they're content). Feature flags have a curated public palette (survivor/bylaws/submit toggleable by editors); the rest are dogfood-only until graduated.
+
 ### Newsletter Privacy
 
 The Editor sets the newsletter visibility:

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,16 @@ service cloud.firestore {
     // -----------------------------------------------------------------------
     match /leagues/{leagueId} {
       allow read: if true;
-      allow create: if request.auth != null;
+      // Shape-validated: doc IDs are predictable platform IDs and updates are
+      // denied, so an unvalidated create would let anyone permanently poison
+      // a league's metadata/features before the legitimate auto-seed runs.
+      allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(
+             ['platform', 'platformLeagueId', 'name', 'season', 'features', 'createdAt'])
+        && request.resource.data.platform in ['sleeper', 'espn', 'yahoo']
+        && request.resource.data.name is string
+        && request.resource.data.season is int
+        && request.resource.data.features is list;
       allow update, delete: if false;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,61 +22,15 @@ service cloud.firestore {
 
     // -----------------------------------------------------------------------
     // /leagues/{leagueId}
-    // Publicly readable (privacy defaults to public for Phase 1).
-    // Only the editor (editorUid) or co-editors can write.
+    // Platform metadata cache (demoted by #103/#110 — editor/privacy live on
+    // /newsletters now). Publicly readable; any signed-in visit may seed the
+    // doc; no client updates or deletes (league-doc `features` for the legacy
+    // experience are console-edited until #103 ladder step 5).
     // -----------------------------------------------------------------------
     match /leagues/{leagueId} {
       allow read: if true;
-      // Docs are created unclaimed (editorUid null); creating a doc that
-      // names an editor is only allowed if that editor is yourself.
-      // coEditorUids must start empty — otherwise a stranger could pre-create
-      // the doc with themselves as co-editor and retain write access after a
-      // real member claims the (seemingly unclaimed) editor role.
-      allow create: if request.auth != null
-        && (request.resource.data.editorUid == null
-            || request.resource.data.editorUid == request.auth.uid)
-        && request.resource.data.coEditorUids.size() == 0;
-      allow delete: if request.auth != null
-        && (resource.data.editorUid == request.auth.uid
-            || request.auth.uid in resource.data.coEditorUids);
-      // Co-editors can update fields but never the co-editor list itself —
-      // otherwise one co-editor could strip the others or add strangers.
-      allow update: if request.auth != null
-        && (resource.data.editorUid == request.auth.uid
-            || (request.auth.uid in resource.data.coEditorUids
-                && request.resource.data.coEditorUids == resource.data.coEditorUids));
-      // One-time claim of an unclaimed editor role: only the editorUid field
-      // may change, and only to the claimer's own UID. First write wins —
-      // a concurrent second claim fails this rule because editorUid is no
-      // longer null.
-      allow update: if request.auth != null
-        && resource.data.editorUid == null
-        && request.resource.data.editorUid == request.auth.uid
-        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['editorUid']);
-
-      // ---------------------------------------------------------------------
-      // /leagues/{leagueId}/newsletters/{weekNumber}
-      // DEPRECATED by #103: weekly editions now live at
-      // /newsletters/{id}/issues. No code writes here anymore; this block
-      // stays (harmless, fails safe) until sub-issue C removes the old model.
-      // ---------------------------------------------------------------------
-      match /newsletters/{weekNumber} {
-        allow read: if true;
-        allow write: if request.auth != null
-          && (get(/databases/$(database)/documents/leagues/$(leagueId)).data.editorUid == request.auth.uid
-              || request.auth.uid in get(/databases/$(database)/documents/leagues/$(leagueId)).data.coEditorUids);
-      }
-
-      // ---------------------------------------------------------------------
-      // /leagues/{leagueId}/weekData/{weekNumber}
-      // Publicly readable. Writable by league editor or co-editors.
-      // ---------------------------------------------------------------------
-      match /weekData/{weekNumber} {
-        allow read: if true;
-        allow write: if request.auth != null
-          && (get(/databases/$(database)/documents/leagues/$(leagueId)).data.editorUid == request.auth.uid
-              || request.auth.uid in get(/databases/$(database)/documents/leagues/$(leagueId)).data.coEditorUids);
-      }
+      allow create: if request.auth != null;
+      allow update, delete: if false;
     }
 
     // -----------------------------------------------------------------------

--- a/src/components/constants/NewsletterConstants.ts
+++ b/src/components/constants/NewsletterConstants.ts
@@ -1,0 +1,16 @@
+import type { LeagueFeature } from "../../types/firestore";
+
+/**
+ * Features editors can toggle themselves on their newsletter (#110).
+ *
+ * Everything else (`hotdogs`, `leaderboards`, `custom-newsletters`,
+ * `weekly-recaps`) is dogfood-only: renderable when present on a doc (set
+ * via console for The Offensive Line) but not user-settable — their pages
+ * are still hardcoded to our league until #103 ladder step 4. Graduating a
+ * feature = adding it here.
+ */
+export const TOGGLEABLE_FEATURES: { feature: LeagueFeature; label: string }[] = [
+  { feature: "survivor", label: "Survivor pool" },
+  { feature: "bylaws", label: "Bylaws" },
+  { feature: "submit", label: "Member submissions" },
+];

--- a/src/components/constants/NewsletterConstants.ts
+++ b/src/components/constants/NewsletterConstants.ts
@@ -18,7 +18,7 @@ export const TOGGLEABLE_FEATURES: {
     feature: "survivor",
     label: "Survivor pool",
     description:
-      "A season-long side game: members pick one NFL team to win each week — no repeats, one loss and you're out.",
+      "A season-long side game: each week, pick one fantasy team in your league to win their matchup — no repeats, one loss and you're out.",
   },
   {
     feature: "bylaws",

--- a/src/components/constants/NewsletterConstants.ts
+++ b/src/components/constants/NewsletterConstants.ts
@@ -9,8 +9,25 @@ import type { LeagueFeature } from "../../types/firestore";
  * are still hardcoded to our league until #103 ladder step 4. Graduating a
  * feature = adding it here.
  */
-export const TOGGLEABLE_FEATURES: { feature: LeagueFeature; label: string }[] = [
-  { feature: "survivor", label: "Survivor pool" },
-  { feature: "bylaws", label: "Bylaws" },
-  { feature: "submit", label: "Member submissions" },
+export const TOGGLEABLE_FEATURES: {
+  feature: LeagueFeature;
+  label: string;
+  description: string;
+}[] = [
+  {
+    feature: "survivor",
+    label: "Survivor pool",
+    description:
+      "A season-long side game: members pick one NFL team to win each week — no repeats, one loss and you're out.",
+  },
+  {
+    feature: "bylaws",
+    label: "Bylaws",
+    description: "A page for your league's constitution: rules, punishments, and precedents.",
+  },
+  {
+    feature: "submit",
+    label: "Member submissions",
+    description: "Let league members send in memes, quotes, and story ideas for the newsletter.",
+  },
 ];

--- a/src/hooks/useLeagueDoc.ts
+++ b/src/hooks/useLeagueDoc.ts
@@ -2,7 +2,8 @@
  * useLeagueDoc — read (and lazily create) the Firestore document for a league.
  *
  * Every league viewed on the site gets a /leagues/{leagueId} document that
- * holds platform-neutral metadata plus editor/privacy state (see issue #52).
+ * holds platform-neutral metadata (demoted by #103/#110 — editor/privacy
+ * live on newsletter docs now; `features` stays for the legacy experience).
  *
  * With `createIfMissing: true` (used on league entry pages like Home), the
  * hook creates the document on first authenticated access, seeding it from
@@ -49,8 +50,6 @@ export function useLeagueDoc(
         platformLeagueId: getPlatformLeagueId(leagueId!),
         name: platformLeague.name,
         season: parseInt(platformLeague.season, 10),
-        editorUid: null,
-        coEditorUids: [],
         features: getSeedFeatures(leagueId!),
       });
       return getLeagueDoc(leagueId!);

--- a/src/hooks/useLeagueDoc.ts
+++ b/src/hooks/useLeagueDoc.ts
@@ -7,7 +7,7 @@
  *
  * With `createIfMissing: true` (used on league entry pages like Home), the
  * hook creates the document on first authenticated access, seeding it from
- * the platform API (league name + season) with an unclaimed editor role.
+ * the platform API (league name + season + seed features).
  * Anonymous visitors never trigger creation — Firestore rules require auth.
  *
  * Without it (used on dashboards), the hook is a plain read: a missing

--- a/src/pages/LeagueNewsletters.tsx
+++ b/src/pages/LeagueNewsletters.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "../contexts/AuthContext";
+import { useLeagueDoc } from "../hooks/useLeagueDoc";
 import { verifyLeagueMembership } from "../utils/leagueClaim";
 import { createNewsletter, getNewslettersForLeague } from "../services/firestoreCrud";
 import { getLeague, getPlatform } from "../utils/api/FantasyAPI";
@@ -202,6 +203,11 @@ function LeagueNewsletters(): React.ReactElement {
     staleTime: 60 * 60 * 1000,
   });
 
+  // Firestore league doc (features): leagues with a hand-written archive get
+  // their auto row labeled as the frozen legacy newsletter.
+  const { data: fsLeagueDoc } = useLeagueDoc(leagueId);
+  const isLegacyLeague = !!fsLeagueDoc?.features?.includes("custom-newsletters");
+
   if (!leagueId) return <Container>Missing league ID</Container>;
 
   const handleCreate = async () => {
@@ -294,11 +300,19 @@ function LeagueNewsletters(): React.ReactElement {
         <Hint>No newsletters exist for this league yet.</Hint>
       )}
       <List>
-        {/* Every league gets the auto-generated experience, newsletter or not */}
+        {/* Every league gets the auto-generated experience, newsletter or not.
+            Leagues with a hand-written archive (custom-newsletters) get it
+            labeled as the frozen legacy newsletter instead (#110). */}
         <NewsletterItem>
           <NewsletterInfo>
-            <NewsletterName>Example newsletter</NewsletterName>
-            <NewsletterMeta>auto-generated stats & recaps · no editor content</NewsletterMeta>
+            <NewsletterName>
+              {isLegacyLeague ? "Legacy newsletter" : "Example newsletter"}
+            </NewsletterName>
+            <NewsletterMeta>
+              {isLegacyLeague
+                ? "hand-written archive · frozen"
+                : "auto-generated stats & recaps · no editor content"}
+            </NewsletterMeta>
             {platformLeague &&
               !(
                 (platformLeague.settings?.last_scored_leg ?? 0) > 0 ||

--- a/src/pages/NewsletterHome.tsx
+++ b/src/pages/NewsletterHome.tsx
@@ -15,7 +15,7 @@ import styled from "styled-components";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "../contexts/AuthContext";
 import { verifyLeagueMembership } from "../utils/leagueClaim";
-import { getNewsletter, updateNewsletter } from "../services/firestoreCrud";
+import { getNewsletter, setNewsletterFeature, updateNewsletter } from "../services/firestoreCrud";
 import { getLeague, getPlatform } from "../utils/api/FantasyAPI";
 import { useNewsletterDoc } from "../hooks/useNewsletterDoc";
 import { setSelectedNewsletter } from "../utils/selectedNewsletter";
@@ -140,6 +140,10 @@ const FeatureRow = styled.label`
   color: ${({ theme }: any) => theme.text};
   cursor: pointer;
   padding: 4px 0;
+
+  input[type="checkbox"] {
+    accent-color: ${({ theme }: any) => theme.newsBlue};
+  }
 `;
 
 const Hint = styled.p`
@@ -173,20 +177,23 @@ function NewsletterHome(): React.ReactElement {
 
   const isSubscribed = !!newsletterId && !!profile?.subscribedNewsletterIds?.includes(newsletterId);
   const [togglingFeature, setTogglingFeature] = useState<LeagueFeature | null>(null);
+  const [featureError, setFeatureError] = useState<string | null>(null);
 
-  // Toggle a palette feature on the newsletter doc. Non-palette (dogfood)
-  // flags are preserved untouched — the UI never offers them (#110).
+  // Toggle a palette feature via atomic arrayUnion/arrayRemove — only the
+  // named flag is touched, so concurrent toggles and console-set dogfood
+  // flags can never be clobbered by a stale cache (#110 review).
   const toggleFeature = async (feature: LeagueFeature) => {
     if (!newsletter || !newsletterId || togglingFeature) return;
     setTogglingFeature(feature);
+    setFeatureError(null);
     try {
-      const current = newsletter.features ?? [];
-      const next = current.includes(feature)
-        ? current.filter((f) => f !== feature)
-        : [...current, feature];
-      await updateNewsletter(newsletterId, { features: next });
+      const enabled = !(newsletter.features ?? []).includes(feature);
+      await setNewsletterFeature(newsletterId, feature, enabled);
       // NavBar shares the ["newsletter", id] query key, so this refreshes its nav too
       await queryClient.invalidateQueries({ queryKey: ["newsletter", newsletterId] });
+    } catch (e) {
+      console.error("Error toggling feature:", e);
+      setFeatureError("Couldn't update that feature — try again.");
     } finally {
       setTogglingFeature(null);
     }
@@ -415,6 +422,7 @@ function NewsletterHome(): React.ReactElement {
             </FeatureRow>
           ))}
           <Hint>Enabled features appear in this newsletter's navigation.</Hint>
+          {featureError && <ErrorText>{featureError}</ErrorText>}
         </>
       )}
     </Container>

--- a/src/pages/NewsletterHome.tsx
+++ b/src/pages/NewsletterHome.tsx
@@ -132,6 +132,12 @@ const IdInput = styled.input`
   width: 220px;
 `;
 
+const FeatureList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
 const FeatureRow = styled.label`
   display: flex;
   align-items: center;
@@ -410,17 +416,19 @@ function NewsletterHome(): React.ReactElement {
           {addError && <ErrorText>{addError}</ErrorText>}
 
           <SectionLabel>Features</SectionLabel>
-          {TOGGLEABLE_FEATURES.map(({ feature, label }) => (
-            <FeatureRow key={feature}>
-              <input
-                type="checkbox"
-                checked={(newsletter.features ?? []).includes(feature)}
-                onChange={() => toggleFeature(feature)}
-                disabled={togglingFeature !== null}
-              />
-              {label}
-            </FeatureRow>
-          ))}
+          <FeatureList>
+            {TOGGLEABLE_FEATURES.map(({ feature, label }) => (
+              <FeatureRow key={feature}>
+                <input
+                  type="checkbox"
+                  checked={(newsletter.features ?? []).includes(feature)}
+                  onChange={() => toggleFeature(feature)}
+                  disabled={togglingFeature !== null}
+                />
+                {label}
+              </FeatureRow>
+            ))}
+          </FeatureList>
           <Hint>Enabled features appear in this newsletter's navigation.</Hint>
           {featureError && <ErrorText>{featureError}</ErrorText>}
         </>

--- a/src/pages/NewsletterHome.tsx
+++ b/src/pages/NewsletterHome.tsx
@@ -19,7 +19,8 @@ import { getNewsletter, updateNewsletter } from "../services/firestoreCrud";
 import { getLeague, getPlatform } from "../utils/api/FantasyAPI";
 import { useNewsletterDoc } from "../hooks/useNewsletterDoc";
 import { setSelectedNewsletter } from "../utils/selectedNewsletter";
-import type { NewsletterSeason } from "../types/firestore";
+import { TOGGLEABLE_FEATURES } from "../components/constants/NewsletterConstants";
+import type { LeagueFeature, NewsletterSeason } from "../types/firestore";
 
 const Container = styled.div`
   display: flex;
@@ -131,6 +132,16 @@ const IdInput = styled.input`
   width: 220px;
 `;
 
+const FeatureRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: ${({ theme }: any) => theme.text};
+  cursor: pointer;
+  padding: 4px 0;
+`;
+
 const Hint = styled.p`
   font-size: 13px;
   color: ${({ theme }: any) => theme.text};
@@ -161,6 +172,25 @@ function NewsletterHome(): React.ReactElement {
   const [subscribing, setSubscribing] = useState(false);
 
   const isSubscribed = !!newsletterId && !!profile?.subscribedNewsletterIds?.includes(newsletterId);
+  const [togglingFeature, setTogglingFeature] = useState<LeagueFeature | null>(null);
+
+  // Toggle a palette feature on the newsletter doc. Non-palette (dogfood)
+  // flags are preserved untouched — the UI never offers them (#110).
+  const toggleFeature = async (feature: LeagueFeature) => {
+    if (!newsletter || !newsletterId || togglingFeature) return;
+    setTogglingFeature(feature);
+    try {
+      const current = newsletter.features ?? [];
+      const next = current.includes(feature)
+        ? current.filter((f) => f !== feature)
+        : [...current, feature];
+      await updateNewsletter(newsletterId, { features: next });
+      // NavBar shares the ["newsletter", id] query key, so this refreshes its nav too
+      await queryClient.invalidateQueries({ queryKey: ["newsletter", newsletterId] });
+    } finally {
+      setTogglingFeature(null);
+    }
+  };
 
   const toggleSubscription = async () => {
     if (!newsletterId || !currentUser || subscribing) return;
@@ -371,6 +401,20 @@ function NewsletterHome(): React.ReactElement {
             count toward league membership.
           </Hint>
           {addError && <ErrorText>{addError}</ErrorText>}
+
+          <SectionLabel>Features</SectionLabel>
+          {TOGGLEABLE_FEATURES.map(({ feature, label }) => (
+            <FeatureRow key={feature}>
+              <input
+                type="checkbox"
+                checked={(newsletter.features ?? []).includes(feature)}
+                onChange={() => toggleFeature(feature)}
+                disabled={togglingFeature !== null}
+              />
+              {label}
+            </FeatureRow>
+          ))}
+          <Hint>Enabled features appear in this newsletter's navigation.</Hint>
         </>
       )}
     </Container>

--- a/src/pages/NewsletterHome.tsx
+++ b/src/pages/NewsletterHome.tsx
@@ -135,21 +135,51 @@ const IdInput = styled.input`
 const FeatureList = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  width: 100%;
+  max-width: 440px;
 `;
 
-const FeatureRow = styled.label`
+const FeatureCard = styled.label`
   display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: ${({ theme }: any) => theme.text};
+  align-items: flex-start;
+  gap: 10px;
+  text-align: left;
+  background-color: ${({ theme }: any) => theme.background};
+  border: 1px solid ${({ theme }: any) => theme.neutral3}44;
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin: 4px 0;
   cursor: pointer;
-  padding: 4px 0;
+  transition: border-color 0.15s ease;
+
+  &:hover {
+    border-color: ${({ theme }: any) => theme.neutral3};
+  }
 
   input[type="checkbox"] {
     accent-color: ${({ theme }: any) => theme.newsBlue};
+    margin-top: 3px;
+    flex-shrink: 0;
   }
+`;
+
+const FeatureText = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const FeatureName = styled.span`
+  font-size: 14px;
+  font-weight: bold;
+  color: ${({ theme }: any) => theme.text};
+`;
+
+const FeatureDescription = styled.span`
+  font-size: 12px;
+  color: ${({ theme }: any) => theme.text};
+  opacity: 0.65;
+  line-height: 1.4;
 `;
 
 const Hint = styled.p`
@@ -417,16 +447,19 @@ function NewsletterHome(): React.ReactElement {
 
           <SectionLabel>Features</SectionLabel>
           <FeatureList>
-            {TOGGLEABLE_FEATURES.map(({ feature, label }) => (
-              <FeatureRow key={feature}>
+            {TOGGLEABLE_FEATURES.map(({ feature, label, description }) => (
+              <FeatureCard key={feature}>
                 <input
                   type="checkbox"
                   checked={(newsletter.features ?? []).includes(feature)}
                   onChange={() => toggleFeature(feature)}
                   disabled={togglingFeature !== null}
                 />
-                {label}
-              </FeatureRow>
+                <FeatureText>
+                  <FeatureName>{label}</FeatureName>
+                  <FeatureDescription>{description}</FeatureDescription>
+                </FeatureText>
+              </FeatureCard>
             ))}
           </FeatureList>
           <Hint>Enabled features appear in this newsletter's navigation.</Hint>

--- a/src/services/firestoreCrud.ts
+++ b/src/services/firestoreCrud.ts
@@ -93,17 +93,16 @@ export async function deleteUser(uid: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a new league document. Sets createdAt and privacy defaults.
+ * Create a new league document (platform metadata cache). Sets createdAt.
  * @param leagueId - Document ID (plain numeric for Sleeper, "espn_XXXXX" for ESPN)
- * @param data - League fields (excluding createdAt; privacy defaults to 'public')
+ * @param data - League fields (excluding createdAt)
  */
 export async function createLeague(
   leagueId: string,
-  data: Omit<LeagueDoc, "createdAt" | "privacy"> & { privacy?: LeagueDoc["privacy"] }
+  data: Omit<LeagueDoc, "createdAt">
 ): Promise<void> {
   await setDoc(doc(db, "leagues", leagueId), {
     ...data,
-    privacy: data.privacy ?? "public",
     createdAt: Timestamp.now(),
   });
 }
@@ -116,19 +115,6 @@ export async function createLeague(
 export async function getLeague(leagueId: string): Promise<LeagueDoc | null> {
   const snap = await getDoc(doc(db, "leagues", leagueId));
   return snap.exists() ? withFeatures(leagueId, snap.data() as LeagueDoc) : null;
-}
-
-/**
- * Fetch all leagues where a given UID is the editor.
- * @param editorUid - Firebase Auth UID of the editor
- * @returns Array of league documents with their IDs.
- */
-export async function getLeaguesByEditor(
-  editorUid: string
-): Promise<(LeagueDoc & { id: string })[]> {
-  const q = query(collection(db, "leagues"), where("editorUid", "==", editorUid));
-  const snap = await getDocs(q);
-  return snap.docs.map((d) => ({ id: d.id, ...withFeatures(d.id, d.data() as LeagueDoc) }));
 }
 
 /**

--- a/src/services/firestoreCrud.ts
+++ b/src/services/firestoreCrud.ts
@@ -10,7 +10,6 @@
  *   /leagues/{leagueId}
  *   /newsletters/{newsletterId}                        (issue #103)
  *   /newsletters/{newsletterId}/issues/{season}_w{week}
- *   /leagues/{leagueId}/weekData/{weekNumber}           (fate decided in #84)
  */
 
 import {
@@ -24,16 +23,18 @@ import {
   getDocs,
   query,
   where,
+  arrayUnion,
+  arrayRemove,
   Timestamp,
 } from "firebase/firestore";
 import { db } from "../firebase";
 import type {
   UserDoc,
   LeagueDoc,
+  LeagueFeature,
   NewsletterDoc,
   NewsletterSeason,
   IssueDoc,
-  WeekDataDoc,
 } from "../types/firestore";
 import { getSeedFeatures } from "../components/constants/LeagueConstants";
 
@@ -115,23 +116,6 @@ export async function createLeague(
 export async function getLeague(leagueId: string): Promise<LeagueDoc | null> {
   const snap = await getDoc(doc(db, "leagues", leagueId));
   return snap.exists() ? withFeatures(leagueId, snap.data() as LeagueDoc) : null;
-}
-
-/**
- * Update fields on an existing league document.
- * @param leagueId - League document ID
- * @param data - Partial league fields to merge
- */
-export async function updateLeague(leagueId: string, data: Partial<LeagueDoc>): Promise<void> {
-  await updateDoc(doc(db, "leagues", leagueId), data);
-}
-
-/**
- * Delete a league document.
- * @param leagueId - League document ID
- */
-export async function deleteLeague(leagueId: string): Promise<void> {
-  await deleteDoc(doc(db, "leagues", leagueId));
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +243,25 @@ export async function updateNewsletter(
 }
 
 /**
+ * Atomically enable/disable a single feature flag on a newsletter.
+ * arrayUnion/arrayRemove touch only the named flag, so concurrent toggles
+ * and console-set dogfood flags can never be clobbered by a stale
+ * read-modify-write (#110 review).
+ * @param newsletterId - Newsletter document ID
+ * @param feature - The flag to toggle
+ * @param enabled - true to add, false to remove
+ */
+export async function setNewsletterFeature(
+  newsletterId: string,
+  feature: LeagueFeature,
+  enabled: boolean
+): Promise<void> {
+  await updateDoc(doc(db, "newsletters", newsletterId), {
+    features: enabled ? arrayUnion(feature) : arrayRemove(feature),
+  });
+}
+
+/**
  * Delete a newsletter document.
  * @param newsletterId - Newsletter document ID
  */
@@ -320,59 +323,4 @@ export async function getIssue(
 export async function getAllIssues(newsletterId: string): Promise<(IssueDoc & { id: string })[]> {
   const snap = await getDocs(collection(db, "newsletters", newsletterId, "issues"));
   return snap.docs.map((d) => ({ id: d.id, ...(d.data() as IssueDoc) }));
-}
-
-// ---------------------------------------------------------------------------
-// WeekData — /leagues/{leagueId}/weekData/{weekNumber}
-// ---------------------------------------------------------------------------
-
-/**
- * Create or overwrite a weekData document (auto-generated stats cache).
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
- * @param data - Week data fields
- */
-export async function setWeekData(
-  leagueId: string,
-  weekNumber: string,
-  data: WeekDataDoc
-): Promise<void> {
-  await setDoc(doc(db, "leagues", leagueId, "weekData", weekNumber), data);
-}
-
-/**
- * Fetch a weekData document for a given week.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
- * @returns The weekData document or null if not found.
- */
-export async function getWeekData(
-  leagueId: string,
-  weekNumber: string
-): Promise<WeekDataDoc | null> {
-  const snap = await getDoc(doc(db, "leagues", leagueId, "weekData", weekNumber));
-  return snap.exists() ? (snap.data() as WeekDataDoc) : null;
-}
-
-/**
- * Update fields on an existing weekData document.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
- * @param data - Partial weekData fields to merge
- */
-export async function updateWeekData(
-  leagueId: string,
-  weekNumber: string,
-  data: Partial<WeekDataDoc>
-): Promise<void> {
-  await updateDoc(doc(db, "leagues", leagueId, "weekData", weekNumber), data);
-}
-
-/**
- * Delete a weekData document.
- * @param leagueId - Parent league document ID
- * @param weekNumber - Week number as string
- */
-export async function deleteWeekData(leagueId: string, weekNumber: string): Promise<void> {
-  await deleteDoc(doc(db, "leagues", leagueId, "weekData", weekNumber));
 }

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -73,8 +73,11 @@ export interface UserDoc {
 /**
  * /leagues/{leagueId}
  *
- * Represents a fantasy league. The document ID encodes the platform:
- * plain numeric for Sleeper, "espn_XXXXX" for ESPN.
+ * Platform metadata for a league-season. The document ID encodes the
+ * platform: plain numeric for Sleeper, "espn_XXXXX" for ESPN.
+ *
+ * Demoted by #103: editor/privacy now live on NewsletterDoc. `features`
+ * stays until ladder step 5 — the legacy league-home nav reads it.
  */
 export interface LeagueDoc {
   /** Which fantasy platform this league belongs to. */
@@ -85,12 +88,6 @@ export interface LeagueDoc {
   name: string;
   /** NFL season year (e.g. 2025). */
   season: number;
-  /** Firebase UID of the primary editor. Null until a member claims the role. */
-  editorUid: string | null;
-  /** Firebase UIDs of co-editors who can also edit newsletters. */
-  coEditorUids: string[];
-  /** Privacy setting. Defaults to 'public' for Phase 1. */
-  privacy: Privacy;
   /** Extra features enabled for this league. Empty = base experience only. */
   features: LeagueFeature[];
   /** Timestamp when the league document was created. */

--- a/src/utils/leagueClaim.ts
+++ b/src/utils/leagueClaim.ts
@@ -1,5 +1,5 @@
 /**
- * leagueClaim — membership verification and editor-role claiming (#53).
+ * leagueClaim — league membership verification.
  *
  * Membership is verified client-side per the launch plan's MVP approach
  * (Sleeper has no OAuth; newsletters are low-stakes content):
@@ -8,12 +8,10 @@
  *   - ESPN / Yahoo: successfully fetching the league's users counts —
  *     private leagues require the user's own credentials to fetch at all.
  *
- * Real enforcement of the claim itself lives in firestore.rules: an
- * unclaimed league (editorUid null) can only transition to the claimer's
- * own UID, touching no other fields. First write wins.
+ * The editor-role claim flow (#53) retired in #110: creating a newsletter
+ * IS claiming in the #103 model.
  */
 import { getUsers, getPlatform } from "./api/FantasyAPI";
-import { updateLeague } from "../services/firestoreCrud";
 import type { UserProfile } from "./survivorUtils";
 
 export interface MembershipResult {
@@ -49,26 +47,5 @@ export async function verifyLeagueMembership(
     return { isMember: true };
   } catch {
     return { isMember: false, reason: "fetch-failed" };
-  }
-}
-
-/**
- * Claim the editor role for a league. Firestore rules guarantee this only
- * succeeds while the role is unclaimed — a permission error almost always
- * means someone else claimed it first.
- */
-export async function claimEditorRole(
-  leagueId: string,
-  uid: string
-): Promise<{ success: boolean; error?: string }> {
-  try {
-    await updateLeague(leagueId, { editorUid: uid });
-    return { success: true };
-  } catch (error) {
-    console.error("Error claiming editor role:", error);
-    return {
-      success: false,
-      error: "Couldn't claim the editor role — it may have just been claimed by someone else.",
-    };
   }
 }


### PR DESCRIPTION
## Summary

Sub-issue C of #103 (closes #110): the freeze-and-parallel migration begins.

- **Editor feature toggles** on the newsletter home — a curated palette (Survivor pool / Bylaws / Member submissions) rendered as cards with descriptions. Dogfood flags (`hotdogs`, `leaderboards`, `custom-newsletters`, `weekly-recaps`) render when present on a doc but are never user-settable; graduating a feature = adding it to `TOGGLEABLE_FEATURES`. Toggles write via atomic `arrayUnion`/`arrayRemove` (`setNewsletterFeature`) so stale caches can't clobber console-set flags, with error feedback on failure.
- **Legacy labeling:** leagues whose doc carries `custom-newsletters` get their discovery-page auto row labeled "Legacy newsletter — hand-written archive · frozen"; everyone else keeps "Example newsletter".
- **Claim machinery retired:** `claimEditorRole`, `getLeaguesByEditor`, and `editorUid`/`coEditorUids`/`privacy` on league docs are gone (creation = claiming in the newsletter model). `/leagues` rules simplify to public read + shape-validated authenticated create + no client update/delete; the one-time-claim rules and the deprecated `/leagues/*/newsletters` + `weekData` blocks are deleted. Rules-denied dead CRUD exports (`updateLeague`, `deleteLeague`, weekData functions) deleted so future callers fail at compile time.
- **Docs:** freeze-and-parallel ladder recorded in `public-launch-plan.md` (and on #103).

## Review

Six-agent review (1 Fable, 2 Opus, 3 Sonnet), findings validated against the code and dispositioned one-by-one with Matthew: fixed the `/leagues` create-rule poisoning vector (shape validation), the stale-cache feature wipe (atomic writes), silent toggle failures, checkbox theming/alignment, stale docs, and dead exports. Deliberately kept: prior-season league docs stay "Example newsletter" (reversible via seed map), toggle label copy.

## Test plan

- `pnpm lint` / `pnpm typecheck` / `pnpm format:check` pass; Jest 130/130
- Emulator walkthrough by Matthew: palette toggles gate the newsletter nav live, dogfood flags survive toggling, legacy-labeled row on the main league, fresh league docs create with the new shape, no claim UI, A/B flows unaffected

## Post-merge (Matthew, prod)

Rules auto-deploy (league docs become client-immutable — nothing in the app writes them). Seed The Offensive Line newsletter via the UI: create + chain-add 2024/2023 + tick the palette toggles, then console-set `hotdogs` + `leaderboards` on the newsletter doc (`custom-newsletters`/`weekly-recaps` only act on the league doc, which the seed map already covers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)