### PR TITLE
Add 2026 newsletters and update league ID

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+node-linker=hoisted
 public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*babel*

--- a/package.json
+++ b/package.json
@@ -82,5 +82,10 @@
     "html-loader": "^4.2.0",
     "prettier": "^3.8.1"
   },
-  "packageManager": "pnpm@10.30.0"
+  "packageManager": "pnpm@10.30.0",
+  "pnpm": {
+    "overrides": {
+      "semver": "7.7.4"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  semver: 7.7.4
+
 importers:
 
   .:
@@ -7688,10 +7691,6 @@ packages:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
     engines: {node: '>=8'}
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -9053,7 +9052,7 @@ snapshots:
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9063,7 +9062,7 @@ snapshots:
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
+      semver: 7.7.4
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -9083,7 +9082,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.7.4
 
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -9094,7 +9093,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9103,7 +9102,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
-      semver: 6.3.1
+      semver: 7.7.4
 
   '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.0)':
     dependencies:
@@ -9726,7 +9725,7 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9864,7 +9863,7 @@ snapshots:
       babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
       core-js-compat: 3.48.0
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12548,7 +12547,7 @@ snapshots:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13895,7 +13894,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
@@ -13957,7 +13956,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.6
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -15410,7 +15409,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -16518,7 +16517,7 @@ snapshots:
 
   make-dir@3.1.0:
     dependencies:
-      semver: 6.3.1
+      semver: 7.7.4
 
   make-dir@4.0.0:
     dependencies:
@@ -16988,7 +16987,7 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
-      semver: 6.3.1
+      semver: 7.7.4
 
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
@@ -18563,9 +18562,7 @@ snapshots:
 
   semver-diff@3.1.1:
     dependencies:
-      semver: 6.3.1
-
-  semver@6.3.1: {}
+      semver: 7.7.4
 
   semver@7.7.4: {}
 

--- a/src/components/constants/LeagueConstants.ts
+++ b/src/components/constants/LeagueConstants.ts
@@ -1,7 +1,7 @@
 import type { LeagueFeature } from "../../types/firestore";
 
 export const leagueIds = {
-  mainLeague: "1253779168802377728",
+  mainLeague: "1382521746292219904",
   walterPicks: "1223730601350135814",
 } as const;
 

--- a/src/newsletters/2025/2025 Week 16/2025 Week 16.jsx
+++ b/src/newsletters/2025/2025 Week 16/2025 Week 16.jsx
@@ -457,7 +457,7 @@ const LeagueBuzzArticle = () => {
         evidence supporting the case that the toilet bowl punishment was supposed to always be a
         song. If anyone has any evidence in favor of that argument, please send it to The Offensive
         Line immediately. The{" "}
-        <a href="../1253779168802377728/2024%20Week%2016">2024 Week 16 newsletter</a> has coverage
+        <a href="../1382521746292219904/2024%20Week%2016">2024 Week 16 newsletter</a> has coverage
         of the discussion that was had, but no mention of this punishment persisting year to year.
       </p>
       <ArticleSubheader>League Submissions</ArticleSubheader>

--- a/src/newsletters/2026/League Member Updates 2026/League Member Updates 2026.jsx
+++ b/src/newsletters/2026/League Member Updates 2026/League Member Updates 2026.jsx
@@ -1,0 +1,325 @@
+import styled from "styled-components";
+import { ArticleHeader } from "../../../components/newsletters/newsStyles";
+
+const QABlock = styled.div`
+  margin-bottom: 14px;
+  padding-left: 12px;
+  border-left: 2px solid ${({ theme }) => theme.newsBlue};
+`;
+
+const Question = styled.p`
+  font-style: italic;
+  font-size: 13px;
+  margin: 0 0 4px 0;
+  color: ${({ theme }) => theme.text};
+  opacity: 0.85;
+`;
+
+const Answer = styled.p`
+  font-weight: 500;
+  font-size: 15px;
+  margin: 0;
+  line-height: 1.5;
+`;
+
+const MemberDivider = styled.hr`
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.text}33;
+  margin: 24px 0;
+`;
+
+const MemberQA = ({ question, answer }) => (
+  <QABlock>
+    <Question>{question}</Question>
+    <Answer>{answer}</Answer>
+  </QABlock>
+);
+
+const MemberUpdate = ({ name, answers, isLast }) => {
+  const questions = [
+    "1. If your name is Devan, are you still alive?",
+    "2. Where are you living these days? City and neighborhood, and did you move in the last year?",
+    "3. What's your job situation? Company, role, and whether it's new since last season.",
+    "4. Relationship status: Any changes since last year?",
+    "5. Any new additions to the family?",
+    "6. Biggest trip you took this year — where'd you go and who with?",
+    "7. Any upcoming trips?",
+    "8. What's taking up your time?",
+    "9. Who do you think will lose the league this year?",
+    "10. Anything else you want the league to know?",
+  ];
+  return (
+    <div>
+      <ArticleHeader>{name}</ArticleHeader>
+      {questions.map((q, i) => (
+        <MemberQA key={i} question={q} answer={answers[i]} />
+      ))}
+      {!isLast && <MemberDivider />}
+    </div>
+  );
+};
+
+const NikhilArticle = () => (
+  <MemberUpdate
+    name="Nikhil"
+    isLast={false}
+    answers={[
+      "Negative",
+      "Boston for now",
+      "New: Principal robotics software engineer",
+      "No change to report",
+      "My plants have died",
+      "Work trip to the UK",
+      "AUSTRALIA",
+      "Games (both video and board) and volleyball",
+      "Me",
+      "RIP Devan",
+    ]}
+  />
+);
+
+const JakeArticle = () => (
+  <MemberUpdate
+    name="Jake"
+    isLast={false}
+    answers={[
+      "N/A",
+      "Geneseo NY",
+      "Same Job",
+      "Engaged",
+      "No",
+      "Disney with the whole family!",
+      "No",
+      "Soccer, Video Games, Sports Cards",
+      "Trevor",
+      "Hi \u2764\ufe0f",
+    ]}
+  />
+);
+
+const JoshLittleArticle = () => (
+  <MemberUpdate
+    name="Josh Little"
+    isLast={false}
+    answers={[
+      "I think he's dead and Emily hijacked his socials",
+      "I live in Park Ave, Rochester, I'm moving soon to another apartment on Park Ave soon",
+      "My company was purchased last year and I was lucky to get hired on to the new company as a Service Desk Manager, associate 2.",
+      "I'm dating Kate, she's pretty cool.",
+      "Negative, just growing my beer belly",
+      "I went to Las Vegas with my family for the Raiders Broncos game, and ran the Hoover Dam half marathon.",
+      "Washington D.C for a Nationals Game and other things",
+      "I've been playing the new resident evil game, Apex, and Siege. Trying to learn the guitar too.",
+      "Probably Alec, but hopefully someone new like Greg",
+      "Suggestion: I know making a good video is fun, but it's not fun if everyone is late on them. I think there should be a fine enforced for late videos by commish, that goes to league fund.",
+    ]}
+  />
+);
+
+const AlecArticle = () => (
+  <MemberUpdate
+    name="Alec"
+    isLast={false}
+    answers={[
+      "N/A",
+      "A nice house on a quiet dead end street in NH - this will be my 3rd year here",
+      "I'm a project manager at BAE - I heard Cats",
+      "3 years with Siobhan",
+      "I have a sick garden",
+      "Japan - October 2025 with friends",
+      "Ireland. In July.",
+      "Too many",
+      "Probably me",
+      "Check your balls for lumps - I had a scare (I'm okay)",
+    ]}
+  />
+);
+
+const MattRobArticle = () => (
+  <MemberUpdate
+    name="Matt Rob"
+    isLast={false}
+    answers={[
+      "I'm not Devan. Hope he's alive though.",
+      "Henrietta NY. Built house and moved in on 09 June 2025",
+      "Salesforce - Senior Incident Responder (same)",
+      "Single. Kiara and I broke up end of Jan / early Feb. I'm in shambles.",
+      "Nala is new as of the middle of last year. She's almost a year old now. She's a Pure Bred Working Line German Shepherd.",
+      "All my PTO this year has been to decompress at home. Mental health is struggling.",
+      "No upcoming trips.",
+      "Nala takes up just about all my time.",
+      "Good question. Hard to say, but have to put money on Dev, just because he's been so inactive, that I think he won't pay attention much.",
+      "No.",
+    ]}
+  />
+);
+
+const DevanArticle = () => (
+  <MemberUpdate
+    name="Devan"
+    isLast={false}
+    answers={[
+      "Devdawg is alive and well. Been so damn busy, life, work, hobbies etc, working on being better with my phone lol",
+      "Moved in with Emily (girlfriend you've met before) last February here in good ole Binghamton NY and started a new job (Quality Engineer) at George Industries (make chassis for aerospace/defense industry).",
+      "Going off of #2, I was QE for 8 months, promoted to Supplier Quality in January, then took over director of QA temporarily for 3 months since my boss was fired in February. Negotiating a new salary currently given my role has completely changed and I'm wearing a lot of hats.",
+      "Still with Em, plans to propose coming soon \uD83D\uDC40",
+      "We are an anti pet household lol but we love our friends who have them \uD83D\uDC36",
+      "Trip to Orlando FL for Em's best friends wedding and we had a blast. Went to Universal and felt like a kid again. Airbnb on a golf course and really couldn't ask for anything more.",
+      "No trips planned currently, just the lake in the summertime most weekends and the occasional trip to Cuse to see the boys and family.",
+      "Being a homeowner is way more work than I thought, lot of time and energy into it. Hobbies (still playing rec sports). Work nowadays has been a lot. Plans out the wazoo with Em's fam or the fellas or doing house projects.",
+      "I hope Alec loses this year.",
+      "Missing all the boys. Wish we could go back to the days where we went to volleyball and then the landing strip...wish I had a better PTO schedule because I'd love to get together with the fellas soon and catch up. I haven't forgot about the punishment but please someone send me exactly what it is I have to do lol because I forget all the rules/regs of it. Finally, you won't catch me losing ever again. Coming for 1st next season.",
+    ]}
+  />
+);
+
+const TrevorArticle = () => (
+  <MemberUpdate
+    name="Trevor"
+    isLast={false}
+    answers={[
+      "No",
+      "Buffalo, same place west side, looking to move to elmwood village",
+      "Still at WalterPicks, just got big raise and new 5 year equity agreement",
+      "Dating, ring shopping for engagement which will likely be by the end of the year or early next year",
+      "We got a cat named Linus in January",
+      "Going to Seattle this week to visit Anthony, other than that the draft for work",
+      "Going to Florida and Cape Cod for work, likely a tropical vacation in winter but unplanned rn",
+      "TrevorSolves has been fun to build up, just hit 1k followers on TikTok",
+      "Alec but I hope Anthony",
+      "The Offensive Line is sick and we need to get people using it outside of us, maybe another TikTok channel is needed.",
+    ]}
+  />
+);
+
+const KyleArticle = () => (
+  <MemberUpdate
+    name="Kyle"
+    isLast={false}
+    answers={[
+      "N/A",
+      "Corn Hill in Rochester, NY and yes I did move",
+      "PhD Student in Biomedical Engineering, no change",
+      "Dating, no changes other than moving in together in August 2025",
+      "New pet, Stevie a 4 month old rescue puppy (breed unconfirmed, suspected Australian shepherd/border collie/other)",
+      "Charlotte, NC for a conference with my lab",
+      "DC for another conference and then Arizona for a bachelor party",
+      "School work unfortunately takes a lot of time up, other than that playing tennis and basketball for fun and the puppy takes up a lot of time right now too.",
+      "Devan if he is alive and even plays",
+      "N/A",
+    ]}
+  />
+);
+
+const JoshKArticle = () => (
+  <MemberUpdate
+    name="Josh K"
+    isLast={false}
+    answers={[
+      "N/A",
+      "Astoria, the beating heart of Mamdanistan. Will be making an in-neighborhood move at the end of the month.",
+      "Still SW engineering at MLB",
+      "Single",
+      "In the process of building a robot",
+      "Multi continental trip w/ Tony and food poisoning",
+      "Nothing planned, but will be re-evaluating soon",
+      "Gym + practicing piano/guitar freestyling",
+      "This is Alec's year to lose. Devan's autodraft is gonna cook.",
+      "Mike Vrabel innocent.",
+    ]}
+  />
+);
+
+const AnthonyArticle = () => (
+  <MemberUpdate
+    name="Anthony"
+    isLast={false}
+    answers={[
+      "N/A",
+      "Seattle at Greenlake. I moved last September and loveeee where I am now.",
+      "Still at Salesforce doing my fake job",
+      "Single",
+      "N/A",
+      "I went to Japan with 5 friends and it was fucking lit. I also went to Hawaii and Thailand in my recent life. Thailand was epic. Also went to Tunisia with Josh which was so fun.",
+      "Griztronics at the Gorge soon. Weekend EDM festival with tons of friends.",
+      "Running, climbing, random debauchery, general outdoor activities",
+      "Alec",
+      "I'm very excited to see everyone in September :)",
+    ]}
+  />
+);
+
+const MattSmithArticle = () => (
+  <MemberUpdate
+    name="Matt Smith"
+    isLast={false}
+    answers={[
+      "N/A",
+      "Just moved into an apartment in a neighborhood called Mueller in Austin. First time living alone, excited for that.",
+      "Currently partaking in a hostile RIT takeover of Salesforce",
+      "Single, broke up with Peggy back in February",
+      "Plants are thriving for the most part. Want to get a dog but also seems like a lot of work.",
+      "Trip to Big Bend with my Dad, did a big hike there and then continued on to White Sands National Park, Guadalupe Mountains National Park, and Carlsbad Caverns.",
+      "Visiting family on Long Island in July, nothing else planned besides trips for Gregothy.",
+      "Playing Hockey and Volleyball, going to a decent number of concerts, watching Attack on Titan right now, kinda learning the guitar.",
+      "I think Greg will lose the league this year.",
+      "I want the league to know that Nikhil is a fraud and bad at Fantasy football.",
+    ]}
+  />
+);
+
+const GregArticle = () => (
+  <MemberUpdate
+    name="Greg"
+    isLast={true}
+    answers={[
+      "No",
+      "Medford MA",
+      "BAE Systems, MFG ENG same role",
+      "Engaged",
+      "No kids or pets",
+      "Alaska with Hannah",
+      "Tulum, St Lucia and Italy or Greece",
+      "League of Legends, Sopranos, School",
+      "Matt",
+      "No.",
+    ]}
+  />
+);
+
+const IntroArticle = () => {
+  return (
+    <div>
+      <ArticleHeader>Offseason 2026 Questionnaire / Devan Wellness Check</ArticleHeader>
+      <p>
+        I hope you enjoy these little peaks into each other's lives! Life gets busy and it's hard to
+        keep up with everyone.
+      </p>
+    </div>
+  );
+};
+
+const newsletterData = {
+  newsDate: "2026-08-14",
+  articles: [
+    { id: 1, content: IntroArticle },
+    { id: 2, content: NikhilArticle },
+    { id: 3, content: JakeArticle },
+    { id: 4, content: JoshLittleArticle },
+    { id: 5, content: AlecArticle },
+    { id: 6, content: MattRobArticle },
+    { id: 7, content: DevanArticle },
+    { id: 8, content: TrevorArticle },
+    { id: 9, content: KyleArticle },
+    { id: 10, content: JoshKArticle },
+    { id: 11, content: AnthonyArticle },
+    { id: 12, content: MattSmithArticle },
+    { id: 13, content: GregArticle },
+  ],
+  meta: {
+    title: "League Member Updates 2026",
+    description: "Life updates from each league member ahead of the 2026 season.",
+  },
+};
+
+export default newsletterData;

--- a/src/newsletters/2026/Off Season Address 2026/Off Season Address 2026.jsx
+++ b/src/newsletters/2026/Off Season Address 2026/Off Season Address 2026.jsx
@@ -53,19 +53,21 @@ const OffSeasonAddressArticle = () => {
         We will also see a change to MOTW for this season. Instead of the hotdog/shot bet, the
         standard MOTW bet will be $15 between the two managers in MOTW. If the two managers in MOTW
         want to make another bet to replace the $15 bet, they are able to do that. MOTW timeline for
-        completion remains the same, and there will be less forgiveness now that this is self imposed.
+        completion remains the same, and there will be less forgiveness now that this is self
+        imposed.
       </p>
       <ArticleSubheader>League Member Updates</ArticleSubheader>
       <p>
-        Attached you will find life updates from each league member. I hope that you appreciate these
-        and learn something new about where our league members are in their lives - time is flying
-        and we are scattered around. These are <em>a little</em> outdated now so anyone who would
-        like to provide futher updates in the groupchat can do so.
+        Attached you will find life updates from each league member. I hope that you appreciate
+        these and learn something new about where our league members are in their lives - time is
+        flying and we are scattered around. These are <em>a little</em> outdated now so anyone who
+        would like to provide futher updates in the groupchat can do so.
       </p>
-      <a href="./League%20Member%20Updates%202026" style={{ textDecoration: "none", display: "block", margin: "16px 0" }}>
-        <StyledButton style={{ width: "100%" }}>
-          Read League Member Updates 2026
-        </StyledButton>
+      <a
+        href="./League%20Member%20Updates%202026"
+        style={{ textDecoration: "none", display: "block", margin: "16px 0" }}
+      >
+        <StyledButton style={{ width: "100%" }}>Read League Member Updates 2026</StyledButton>
       </a>
       <p>
         I cannot wait for this next season to be upon us! Miss you all, and hope everything is going

--- a/src/newsletters/2026/Off Season Address 2026/Off Season Address 2026.jsx
+++ b/src/newsletters/2026/Off Season Address 2026/Off Season Address 2026.jsx
@@ -1,0 +1,92 @@
+import {
+  ArticleHeader,
+  ArticleSubheader,
+  StyledButton,
+} from "../../../components/newsletters/newsStyles";
+
+const newsletterData = {
+  newsDate: "2026-08-14",
+  articles: [],
+  meta: {
+    title: "2026 Offseason Address",
+    description: "The Commissioner's offseason address for the 2026 season.",
+  },
+};
+
+const OffSeasonAddressArticle = () => {
+  return (
+    <div>
+      <ArticleHeader>2026 Offseason Address</ArticleHeader>
+      <p>Dear Fantasy Football Managers,</p>
+      <p>
+        I hope this letter finds you well! Last season was an exciting one, full of drama, close
+        games, and as far as I remember, no gate-worthy controversy. I am excited to get started on
+        the 2026 season!
+      </p>
+      <ArticleSubheader>Draft Order</ArticleSubheader>
+      <p>
+        It is that time of the year where we need to determine the draft order for drafting our
+        leagues draft order. We will return to drafting LLWS teams. We will draft in reverse order
+        of the final standing for last year.
+      </p>
+      <p>Devan, you are on the clock.</p>
+      <ArticleSubheader>Draft Date and Time</ArticleSubheader>
+      <p>
+        A first for our league, the draft will occur in person this year over Labor Day weekend!
+        Draft time is set in the sleeper app, and I am excited for the first in person draft! I
+        appreciate everyone's flexibility in this matter.
+      </p>
+      <ArticleSubheader>League Changes</ArticleSubheader>
+      <p>
+        Let's continue to discuss any rule changes for our league in the discord. There are some
+        changes that were proposed during last season that we will continue to discuss, and I'm sure
+        we will have new proposals. Voting will begin shortly, but I don't see much changing from
+        last year.
+      </p>
+      <ArticleSubheader>Punishment</ArticleSubheader>
+      <p>
+        This year, and for the foreseeable future, the punishment is for the loser of the league to
+        make a song, with the loser of the toilet bowl featuring on that song.
+      </p>
+      <ArticleSubheader>MOTW</ArticleSubheader>
+      <p>
+        We will also see a change to MOTW for this season. Instead of the hotdog/shot bet, the
+        standard MOTW bet will be $15 between the two managers in MOTW. If the two managers in MOTW
+        want to make another bet to replace the $15 bet, they are able to do that. MOTW timeline for
+        completion remains the same, and there will be less forgiveness now that this is self imposed.
+      </p>
+      <ArticleSubheader>League Member Updates</ArticleSubheader>
+      <p>
+        Attached you will find life updates from each league member. I hope that you appreciate these
+        and learn something new about where our league members are in their lives - time is flying
+        and we are scattered around. These are <em>a little</em> outdated now so anyone who would
+        like to provide futher updates in the groupchat can do so.
+      </p>
+      <a href="./League%20Member%20Updates%202026" style={{ textDecoration: "none", display: "block", margin: "16px 0" }}>
+        <StyledButton style={{ width: "100%" }}>
+          Read League Member Updates 2026
+        </StyledButton>
+      </a>
+      <p>
+        I cannot wait for this next season to be upon us! Miss you all, and hope everything is going
+        well!
+      </p>
+      <p>
+        With Love,
+        <br />
+        Your Commissioner
+        <br />
+        Matthew Smith
+      </p>
+    </div>
+  );
+};
+
+newsletterData.articles = [
+  {
+    id: 1,
+    content: OffSeasonAddressArticle,
+  },
+];
+
+export default newsletterData;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -145,10 +145,11 @@ function Home() {
     return issueName;
   };
 
-  // Newsletter content for league ID '1253779168802377728'
+  // Newsletter content for league ID '1382521746292219904'
   const newsletterContent = {
-    mostRecentIssue: ["Hot Dog Tracker", "2025 Season Recap"],
+    mostRecentIssue: ["Hot Dog Tracker", "Off Season Address 2026", "League Member Updates 2026"],
     newsletterIssues: [
+      "2025 Season Recap",
       "2025 Week 17",
       "2025 Week 16",
       "2025 Week 15",

--- a/src/pages/Newsletter.jsx
+++ b/src/pages/Newsletter.jsx
@@ -17,7 +17,7 @@ function formatDate(inputDate) {
 
 export const TeamContext = React.createContext({
   selectedTeam: null,
-  setSelectedTeam: () => { },
+  setSelectedTeam: () => {},
 });
 
 function Newsletter() {

--- a/src/pages/Newsletter.jsx
+++ b/src/pages/Newsletter.jsx
@@ -17,7 +17,7 @@ function formatDate(inputDate) {
 
 export const TeamContext = React.createContext({
   selectedTeam: null,
-  setSelectedTeam: () => {},
+  setSelectedTeam: () => { },
 });
 
 function Newsletter() {
@@ -36,6 +36,9 @@ function Newsletter() {
       if (issue.includes("WP Week")) {
         // Walter Picks newsletters
         folderPath = `WalterPicks/${issue}`;
+      } else if (issue.includes("2026")) {
+        // 2026 newsletters
+        folderPath = `2026/${issue}`;
       } else if (issue.includes("2025")) {
         // 2025 newsletters
         folderPath = `2025/${issue}`;


### PR DESCRIPTION
## Summary

- **New newsletters**: Off Season Address 2026 and League Member Updates 2026
- **League ID update**: `1253779168802377728` → `1382521746292219904` across LeagueConstants, Home.jsx, and 2025 Week 16 newsletter link
- **Routing**: Added 2026 folder path mapping in Newsletter.jsx
- **Navigation**: Added 2026 newsletters to Home.jsx home page
- **pnpm fix**: `node-linker=hoisted` + `semver` override for CRA compatibility
- **Formatting**: Styled Q&A blocks with blue border accents and member dividers in League Member Updates; styled button link from Off Season Address to League Member Updates