### PR TITLE
Add 2026 Breaking News newsletter

### DIFF
--- a/src/newsletters/2026/2026 Breaking News/2026 Breaking News.jsx
+++ b/src/newsletters/2026/2026 Breaking News/2026 Breaking News.jsx
@@ -1,0 +1,73 @@
+import {
+  ArticleHeader,
+} from "../../../components/newsletters/newsStyles";
+
+const BreakingNewsArticle = () => {
+  return (
+    <div>
+      <ArticleHeader>BREAKING NEWS</ArticleHeader>
+      <p>
+        For the first time since our 2022 re-alignment, the league will see a franchise close its
+        doors.
+      </p>
+      <p>
+        Despite the league remaining incredibly profitable, with revenues exceeding projections year
+        after year, it has become increasingly clear that Binghamton is simply not a viable Title IX
+        Fantasy Football market.
+      </p>
+      <p>
+        It is therefore with great sadness that I announce Bye Week Curious will not be returning
+        for the 2026 season.
+      </p>
+      <p>
+        May we not remember his time in this league for his absence, lack of engagement, or general
+        disinterest. Instead, let us remember him for what truly defined his franchise:
+      </p>
+      <p style={{ textAlign: "center", fontStyle: "italic" }}>
+        Being absolutely terrible at fantasy football.
+      </p>
+      <p>As one chapter closes, another begins.</p>
+      <p>
+        We now turn the ship around, put the wind at our backs, and begin the search for the next
+        great Title IX franchise owner. At this time, the two leading candidates to replace Bye
+        Week Curious are:
+      </p>
+      <ul>
+        <li>Matthew Huffman</li>
+        <li>Chris Pursley</li>
+      </ul>
+      <p>
+        Given the short notice, and, more importantly, with league revenue in mind, I would propose
+        that one of these candidates immediately assume control of the vacant franchise, while the
+        other and a third candidate to be named are offered expansion franchises for the 2026
+        season.
+      </p>
+      <p>More owners. More entry fees. More revenue. It's just good business.</p>
+      <p>
+        Please use the group chat to provide thoughts, concerns, endorsements, character
+        assassinations, and/or competing proposals. If necessary, we will bring the matter to a
+        formal league vote.
+      </p>
+      <p style={{ fontWeight: "bold", textAlign: "center" }}>
+        The Title IX Fantasy Football League remains open for business.
+      </p>
+    </div>
+  );
+};
+
+const newsletterData = {
+  newsDate: "2026-08-18",
+  articles: [
+    {
+      id: 1,
+      content: BreakingNewsArticle,
+    },
+  ],
+  meta: {
+    title: "2026 Breaking News",
+    description:
+      "Bye Week Curious will not return for the 2026 season. The search for the next Title IX franchise owner begins.",
+  },
+};
+
+export default newsletterData;

--- a/src/newsletters/2026/2026 Breaking News/2026 Breaking News.jsx
+++ b/src/newsletters/2026/2026 Breaking News/2026 Breaking News.jsx
@@ -1,6 +1,4 @@
-import {
-  ArticleHeader,
-} from "../../../components/newsletters/newsStyles";
+import { ArticleHeader } from "../../../components/newsletters/newsStyles";
 
 const BreakingNewsArticle = () => {
   return (
@@ -29,8 +27,8 @@ const BreakingNewsArticle = () => {
       <p>As one chapter closes, another begins.</p>
       <p>
         We now turn the ship around, put the wind at our backs, and begin the search for the next
-        great Title IX franchise owner. At this time, the two leading candidates to replace Bye
-        Week Curious are:
+        great Title IX franchise owner. At this time, the two leading candidates to replace Bye Week
+        Curious are:
       </p>
       <ul>
         <li>Matthew Huffman</li>

--- a/src/newsletters/2026/2026 League Member Updates/2026 League Member Updates.jsx
+++ b/src/newsletters/2026/2026 League Member Updates/2026 League Member Updates.jsx
@@ -317,7 +317,7 @@ const newsletterData = {
     { id: 13, content: GregArticle },
   ],
   meta: {
-    title: "League Member Updates 2026",
+    title: "2026 League Member Updates",
     description: "Life updates from each league member ahead of the 2026 season.",
   },
 };

--- a/src/newsletters/2026/2026 Off Season Address/2026 Off Season Address.jsx
+++ b/src/newsletters/2026/2026 Off Season Address/2026 Off Season Address.jsx
@@ -64,10 +64,10 @@ const OffSeasonAddressArticle = () => {
         would like to provide futher updates in the groupchat can do so.
       </p>
       <a
-        href="./League%20Member%20Updates%202026"
+        href="./2026%20League%20Member%20Updates"
         style={{ textDecoration: "none", display: "block", margin: "16px 0" }}
       >
-        <StyledButton style={{ width: "100%" }}>Read League Member Updates 2026</StyledButton>
+        <StyledButton style={{ width: "100%" }}>Read 2026 League Member Updates</StyledButton>
       </a>
       <p>
         I cannot wait for this next season to be upon us! Miss you all, and hope everything is going

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -147,8 +147,10 @@ function Home() {
 
   // Newsletter content for league ID '1382521746292219904'
   const newsletterContent = {
-    mostRecentIssue: ["Hot Dog Tracker", "Off Season Address 2026", "League Member Updates 2026"],
+    mostRecentIssue: ["Hot Dog Tracker", "2026 Breaking News"],
     newsletterIssues: [
+      "2026 Off Season Address",
+      "2026 League Member Updates",
       "2025 Season Recap",
       "2025 Week 17",
       "2025 Week 16",


### PR DESCRIPTION
## Summary
- Add new **2026 Breaking News** newsletter announcing Bye Week Curious departing and expansion candidates
- Rename all 2026 newsletter folders/files to year-first format (matching existing years like `2025 Week 1`)
- Update `Home.jsx` with the new newsletter entries
- Fix internal link in Off Season Address to use the renamed folder

## Files changed
- `src/newsletters/2026/2026 Breaking News/2026 Breaking News.jsx` (new)
- `src/newsletters/2026/2026 Off Season Address/2026 Off Season Address.jsx` (renamed + link fix)
- `src/newsletters/2026/2026 League Member Updates/2026 League Member Updates.jsx` (renamed)
- `src/pages/Home.jsx` (updated newsletter list)